### PR TITLE
Json parsing fixes

### DIFF
--- a/acceptable/_service.py
+++ b/acceptable/_service.py
@@ -53,6 +53,13 @@ class AcceptableService:
         keyword argument, which can be used to specify the HTTP method the URL
         will be added for.
         """
+        used_names = [
+            i[1] for i in
+            self._late_registrations + self._completed_registrations]
+        if name in used_names:
+            raise ValueError(
+                "The name '%s' has already been registered for an API."
+                % name)
         api = AcceptableAPI(self)
         if self._flask_app is None:
             self._late_registrations.append((url, name, api, options))

--- a/acceptable/_service.py
+++ b/acceptable/_service.py
@@ -41,16 +41,19 @@ class AcceptableService:
         self._late_registrations = []
         self._completed_registrations = []
 
-    def api(self, url, **options):
-        """Add a URL endpoint.
+    def api(self, url, name, **options):
+        """Add an API to the service.
 
-        The 'url' parameter is passed to the Flask.add_url_rule method. Other
-        keyword arguments may be used, and they will be passed to the
-        underlying flask application.
+        :param url: This is the url that the API should be registered at.
+        :param name: This is the name the URL route should be registered in
+            flask with.
+
+        Other keyword arguments may be used, and they will be passed to the
+        underlying flask application. Of particular interest is the 'methods'
+        keyword argument, which can be used to specify the HTTP method the URL
+        will be added for.
         """
         api = AcceptableAPI(self)
-        name = '%s.%s' % (self.vendor, url)
-        name += ','.join(options.get('methods', []))
         if self._flask_app is None:
             self._late_registrations.append((url, name, api, options))
         else:

--- a/acceptable/tests/test_service.py
+++ b/acceptable/tests/test_service.py
@@ -276,6 +276,20 @@ class AcceptableAPITestCase(TestCase):
 
         self.assertEqual(new_view.foo, 'bar')
 
+    def test_cannot_duplicate_api_names(self):
+        fixture = self.useFixture(SimpleAPIServiceFixture())
+
+        fixture.service.api('/new', 'some name here')
+        e = self.assertRaises(
+            ValueError,
+            fixture.service.api,
+            '/another',
+            'some name here'
+        )
+        self.assertEqual(
+            "The name 'some name here' has already been registered for an "
+            "API.", str(e))
+
 
 class EndpointMapTestCase(TestCase):
 

--- a/acceptable/tests/test_service.py
+++ b/acceptable/tests/test_service.py
@@ -45,7 +45,7 @@ class AcceptableServiceTestCase(TestCase):
 
         app = Flask(__name__)
         service = AcceptableService('vendor', app)
-        api = service.api('/foo')
+        api = service.api('/foo', 'foo_api')
         api.register_view('1.0', None, view)
 
         client = app.test_client()
@@ -58,7 +58,7 @@ class AcceptableServiceTestCase(TestCase):
             return "test view", 200
 
         service = AcceptableService('vendor')
-        api = service.api('/foo')
+        api = service.api('/foo', 'foo_api')
         api.register_view('1.0', None, view)
 
         app = Flask(__name__)
@@ -74,7 +74,7 @@ class AcceptableServiceTestCase(TestCase):
             return "test view", 200
 
         service = AcceptableService('vendor')
-        api = service.api('/foo')
+        api = service.api('/foo', 'foo_api')
         api.register_view('1.0', None, view)
 
         app1 = Flask(__name__)
@@ -97,7 +97,7 @@ class AcceptableServiceTestCase(TestCase):
             return "test view", 200
 
         service = AcceptableService('vendor')
-        api = service.api('/foo')
+        api = service.api('/foo', 'foo_api')
         api.register_view('1.0', None, view)
 
         app1 = Flask(__name__)
@@ -124,14 +124,14 @@ class SimpleAPIServiceFixture(Fixture):
 
         # The /foo API is POST only, and contains three different versioned
         # endpoints:
-        foo_api = self.service.api('/foo', methods=['POST'])
+        foo_api = self.service.api('/foo', 'foo_api', methods=['POST'])
         foo_api.register_view('1.0', None, self.foo_v10)
         foo_api.register_view('1.1', None, self.foo_v11)
         foo_api.register_view('1.3', None, self.foo_v13)
         foo_api.register_view('1.5', None, self.foo_v15)
 
         # The /flagged API is GET only, and has some API flags set:
-        flagged_api = self.service.api('/flagged', methods=['GET'])
+        flagged_api = self.service.api('/flagged', 'flagged', methods=['GET'])
         flagged_api.register_view('1.3', None, self.flagged_v13)
         flagged_api.register_view('1.4', 'feature1', self.flagged_v14_feature1)
         flagged_api.register_view('1.4', 'feature2', self.flagged_v14_feature2)
@@ -220,7 +220,7 @@ class AcceptableAPITestCase(TestCase):
     def test_view_decorator_works(self):
         fixture = self.useFixture(SimpleAPIServiceFixture())
 
-        new_api = fixture.service.api('/new')
+        new_api = fixture.service.api('/new', 'blah')
 
         @new_api.view(introduced_at='1.0')
         def new_view():
@@ -234,7 +234,7 @@ class AcceptableAPITestCase(TestCase):
     def test_can_still_call_view_directly(self):
         fixture = self.useFixture(SimpleAPIServiceFixture())
 
-        new_api = fixture.service.api('/new')
+        new_api = fixture.service.api('/new', 'namegoeshere')
 
         @new_api.view(introduced_at='1.0')
         def new_view():
@@ -249,7 +249,7 @@ class AcceptableAPITestCase(TestCase):
 
         # /foo already exists as a POST endpoint, we should be able to
         # create another /foo API with a GET endpoint.
-        foo_get_api = fixture.service.api('/foo', methods=['GET'])
+        foo_get_api = fixture.service.api('/foo', 'foo', methods=['GET'])
 
         @foo_get_api.view(introduced_at='1.0')
         def get_foo():
@@ -263,7 +263,7 @@ class AcceptableAPITestCase(TestCase):
     def test_view_attributes_are_preserved(self):
         fixture = self.useFixture(SimpleAPIServiceFixture())
 
-        new_api = fixture.service.api('/new')
+        new_api = fixture.service.api('/new', 'new')
 
         def my_decorator(fn):
             fn.foo = 'bar'

--- a/acceptable/tests/test_validation.py
+++ b/acceptable/tests/test_validation.py
@@ -86,6 +86,60 @@ class ValidateBodyTests(TestCase):
             e.error_list
         )
 
+    def test_raises_on_invalid_json(self):
+        app = self.useFixture(FlaskValidateBodyFixture({
+            'type': 'object'
+        }))
+
+        e = self.assertRaises(
+            DataValidationError,
+            app.client.post,
+            '/',
+            data='invalid json',
+            headers={'Content-Type': 'application/json'}
+        )
+        self.assertEqual([
+            "Error decoding json body: Expecting value: "
+            "line 1 column 1 (char 0)"],
+            e.error_list
+        )
+
+    def test_raises_on_wrong_mimetype(self):
+        app = self.useFixture(FlaskValidateBodyFixture({
+            'type': 'object'
+        }))
+
+        e = self.assertRaises(
+            DataValidationError,
+            app.client.post,
+            '/',
+            data='{}',
+            headers={'Content-Type': 'text/plain'}
+        )
+        self.assertEqual([
+            "Expected Json request body, but request has an unexpected "
+            "Content-Type set: text/plain"],
+            e.error_list
+        )
+
+    def test_raises_on_missing_mimetype(self):
+        app = self.useFixture(FlaskValidateBodyFixture({
+            'type': 'object'
+        }))
+
+        e = self.assertRaises(
+            DataValidationError,
+            app.client.post,
+            '/',
+            data='{}',
+            headers={}
+        )
+        self.assertEqual([
+            "Expected Json request body, but request has an unexpected "
+            "Content-Type set: Missing Content-Type"],
+            e.error_list
+        )
+
 
 class ValidateOutputTests(TestCase):
 

--- a/acceptable/tests/test_validation.py
+++ b/acceptable/tests/test_validation.py
@@ -4,6 +4,7 @@ import json
 
 from fixtures import Fixture
 from testtools import TestCase
+from testtools.matchers import StartsWith
 import jsonschema
 
 import flask
@@ -98,10 +99,11 @@ class ValidateBodyTests(TestCase):
             data='invalid json',
             headers={'Content-Type': 'application/json'}
         )
-        self.assertEqual([
-            "Error decoding json body: Expecting value: "
-            "line 1 column 1 (char 0)"],
-            e.error_list
+        # Python 3.3 json decode errors have a different format from later
+        # versions, so this check isn't as explicit as I'd like.
+        self.assertThat(
+            e.error_list[0],
+            StartsWith("Error decoding json body: ")
         )
 
     def test_raises_on_wrong_mimetype(self):


### PR DESCRIPTION
This branch does a few things:

 1. Changes the API registration API such that callers must specify a name for the API. This will allow us to emit statsd metrics per-view with sensible metric names.

2. Error appropriately when flask fails to parse the json body of a request, or when the content-type header is missing.