### PR TITLE
Add build_service_doubles entry point.

### DIFF
--- a/acceptable/_build_doubles.py
+++ b/acceptable/_build_doubles.py
@@ -1,0 +1,269 @@
+# Copyright 2017 Canonical Ltd.  This software is licensed under the
+# GNU Lesser General Public License version 3 (see the file LICENSE).
+
+"""Build Service Doubles:
+
+This module contains the entry point used to extract schemas from python source
+files. The `main` function is installed as a console_script, and has several
+modes of operation:
+
+ - The 'scan_file' command allows a user to scan a random python source file
+   and inspect what service doubles would be extracted from it. This is useful
+   for ensuring that service_doubles can be extracted from a python source file
+   before committing it.
+
+ - The 'build' command takes a config file containing service names and
+   locations, and builds a set of service_doubles based on that config.
+
+In both cases, the service doubles are built by doing an AST parse of the
+python source file in question and extracting calls to acceptable functions.
+"""
+
+import argparse
+import ast
+import collections
+import json
+import logging
+import os.path
+import subprocess
+import sys
+import tempfile
+import textwrap
+
+
+def main():
+    args = parse_args()
+    args.func(args)
+
+
+def parse_args(arg_list=None, parser_class=None):
+    parser = parser_class() if parser_class else argparse.ArgumentParser()
+    subparser = parser.add_subparsers(dest='cmd')
+    subparser.required = True
+    scan_file_parser = subparser.add_parser(
+        'scan-file', help='Scan a file, print extracted service doubles.')
+    scan_file_parser.add_argument('file', type=str)
+    scan_file_parser.set_defaults(func=scan_file)
+
+    build_parser = subparser.add_parser(
+        'build', help='build service mocks.')
+    build_parser.add_argument('config_file', type=str)
+    build_parser.set_defaults(func=build_service_doubles)
+
+    return parser.parse_args(arg_list)
+
+
+def scan_file(args):
+    service_schemas = extract_schemas_from_file(args.file)
+    print(render_service_double('UNKNOWN', service_schemas))
+
+
+def build_service_doubles(args):
+    with tempfile.TemporaryDirectory() as workdir:
+        service_config = read_service_config_file(args.config_file)
+        target_root = os.path.dirname(args.config_file)
+
+        for service in service_config['services']:
+            source_url = SERVICES[service]['git_source']
+            service_dir = fetch_service_source(workdir, service, source_url)
+            service_schemas = []
+            for scan_path in SERVICES[service]['scan_paths']:
+                abs_path = os.path.join(service_dir, scan_path)
+                service_schemas.extend(extract_schemas_from_file(abs_path))
+            rendered = render_service_double(service, service_schemas)
+            write_service_double_file(target_root, service, rendered)
+            print("Rendered schemas file for %s service: %d schemas" % (
+                service, len(service_schemas)))
+
+
+def read_service_config_file(config_path):
+    with open(config_path, 'r') as config_file:
+        return json.load(config_file)
+
+
+def fetch_service_source(workdir, service_name, source_url):
+    print("Cloning source for %s service." % service_name)
+    target_dir = os.path.join(workdir, service_name)
+    subprocess.check_call(
+        ['git', 'clone', source_url, target_dir],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL
+    )
+    return target_dir
+
+
+# ViewSchema contains all the information for a flask view...
+ViewSchema = collections.namedtuple(
+    'ViewSchema',
+    [
+        'view_name',      # The name of the view function.
+        'version',        # The version the view was introduced at.
+        'input_schema',   # The schema for requests to the service.
+        'output_schema',  # The  scheam for responses from the service
+        'methods',        # The methods this view supports.
+        'url',            # The URL this view is mounted at.
+    ]
+)
+
+
+def extract_schemas_from_file(source_path):
+    """Extract schemas from 'source_path'.
+
+    :returns: a list of ViewSchema objects on success, None if not schemas
+        could be extracted.
+    """
+    logging.info("Extracting schemas from %s", source_path)
+    try:
+        with open(source_path, 'r') as source_file:
+            source = source_file.read()
+    except (FileNotFoundError, PermissionError) as e:
+        logging.error("Cannot extract schemas: %s", e.strerror)
+    else:
+        try:
+            schemas = extract_schemas_from_source(source, source_path)
+        except SyntaxError as e:
+            logging.error("Cannot extract schemas: %s", str(e))
+        else:
+            logging.info(
+                "Extracted %d %s",
+                len(schemas),
+                "schema" if len(schemas) == 1 else "schemas")
+            return schemas
+
+
+def extract_schemas_from_source(source, filename='<unknown>'):
+    """Extract schemas from 'source'.
+
+    The 'source' parameters must be a string, and should be valid python
+    source.
+
+    If 'source' is not valid python source, a SyntaxError will be raised.
+
+    :returns: a list of ViewSchema objects.
+    """
+    # Track which acceptable services have been configured.
+    acceptable_services = set()
+    # Track which acceptable views have been configured:
+    acceptable_views = {}
+    schemas_found = []
+    ast_tree = ast.parse(source, filename)
+
+    assigns = [n for n in ast_tree.body if isinstance(n, ast.Assign)]
+    call_assigns = [n for n in assigns if isinstance(n.value, ast.Call)]
+
+    # We need to extract the AcceptableService-related views. We parse the
+    # assignations twice: The first time to extract the AcceptableService
+    # instances, the second to extract the views created on those services.
+    for assign in call_assigns:
+        if isinstance(assign.value.func, ast.Attribute):
+            continue
+        if assign.value.func.id == 'AcceptableService':
+            for target in assign.targets:
+                acceptable_services.add(target.id)
+
+    for assign in call_assigns:
+        # only consider calls which are attribute accesses, AND
+        # calls where the object being accessed is in acceptable_services, AND
+        # calls where the attribute being accessed is the 'api' method.
+        if isinstance(assign.value.func, ast.Attribute) and \
+           assign.value.func.value.id in acceptable_services and \
+           assign.value.func.attr == 'api':
+            # this is a view. We need to extract the url and methods specified.
+            # they may be specified positionally or via a keyword.
+            url = None
+            # methods has a default value:
+            methods = ['GET']
+
+            # This is a view - the URL is the first positional argument:
+            args = assign.value.args
+            if len(args) >= 1:
+                url = ast.literal_eval(args[0])
+            kwargs = assign.value.keywords
+            for kwarg in kwargs:
+                if kwarg.arg == 'url':
+                    url = ast.literal_eval(kwarg.value)
+                if kwarg.arg == 'methods':
+                    methods = ast.literal_eval(kwarg.value)
+            if url:
+                for target in assign.targets:
+                    acceptable_views[target.id] = {
+                        'url': url,
+                        'methods': methods,
+                    }
+
+    # iterate over all functions, attempting to find the views.
+    functions = [n for n in ast_tree.body if isinstance(n, ast.FunctionDef)]
+    for function in functions:
+        input_schema = None
+        output_schema = None
+        api_options = None
+        for decorator in function.decorator_list:
+            if isinstance(decorator.func, ast.Attribute):
+                decorator_name = decorator.func.value.id
+                if decorator_name in acceptable_views:
+                    api_options = acceptable_views[decorator_name]
+            else:
+                decorator_name = decorator.func.id
+                if decorator_name == 'validate_body':
+                    # TODO: Check that nothing in the tree below
+                    # # decorator.args[0] is an instance of 'ast.Name', and
+                    # # print a nice error message if it is.
+                    input_schema = ast.literal_eval(decorator.args[0])
+                if decorator_name == 'validate_output':
+                    output_schema = ast.literal_eval(decorator.args[0])
+        if api_options:
+            schema = ViewSchema(
+                    view_name=function.name,
+                    version='1.0',
+                    input_schema=input_schema,
+                    output_schema=output_schema,
+                    methods=api_options['methods'],
+                    url=api_options['url'],
+                )
+            schemas_found.append(schema)
+    return schemas_found
+
+
+def render_service_double(service_name, schemas):
+    header = textwrap.dedent("""\
+        # This file is AUTO GENERATED. Do not edit this file directly. Instead,
+        # re-generate it by running {progname}.
+
+        from acceptable._doubles import service_mock
+        """.format(progname=sys.argv[0]))
+
+    rendered_schemas = []
+    for schema in schemas:
+        double_name = '%s_%s' % (
+            schema.view_name, schema.version.replace('.', '_'))
+        rendered_schema = textwrap.dedent("""\
+        {double_name} = service_mock(
+            service={service_name!r},
+            methods={schema.methods!r},
+            url={schema.url!r},
+            input_schema={schema.input_schema!r},
+            output_schema={schema.output_schema!r},
+        )
+        """).format(
+            double_name=double_name,
+            schema=schema,
+            service_name=service_name,
+        )
+
+        rendered_schemas.append(rendered_schema)
+
+    rendered_file = '{header}\n\n{schemas}\n'.format(
+        header=header,
+        schemas='\n\n'.join(rendered_schemas)
+    )
+    return rendered_file
+
+
+def write_service_double_file(target_root, service_name, rendered):
+    """Render syntactically valid python service double code."""
+    target_path = os.path.join(
+        target_root,
+        'snapstore_schemas', 'service_doubles', '%s.py' % service_name
+    )
+    with open(target_path, 'w') as target_file:
+        target_file.write(rendered)

--- a/acceptable/_build_doubles.py
+++ b/acceptable/_build_doubles.py
@@ -46,7 +46,7 @@ def parse_args(arg_list=None, parser_class=None):
     scan_file_parser.set_defaults(func=scan_file)
 
     build_parser = subparser.add_parser(
-        'build', help='build service mocks.')
+        'build', help='build service doubles.')
     build_parser.add_argument('config_file', type=str)
     build_parser.set_defaults(func=build_service_doubles)
 
@@ -64,10 +64,10 @@ def build_service_doubles(args):
         target_root = os.path.dirname(args.config_file)
 
         for service in service_config['services']:
-            source_url = SERVICES[service]['git_source']
+            source_url = service['git_source']
             service_dir = fetch_service_source(workdir, service, source_url)
             service_schemas = []
-            for scan_path in SERVICES[service]['scan_paths']:
+            for scan_path in service['scan_paths']:
                 abs_path = os.path.join(service_dir, scan_path)
                 service_schemas.extend(extract_schemas_from_file(abs_path))
             rendered = render_service_double(service, service_schemas)
@@ -99,7 +99,7 @@ ViewSchema = collections.namedtuple(
         'view_name',      # The name of the view function.
         'version',        # The version the view was introduced at.
         'input_schema',   # The schema for requests to the service.
-        'output_schema',  # The  scheam for responses from the service
+        'output_schema',  # The schema for responses from the service
         'methods',        # The methods this view supports.
         'url',            # The URL this view is mounted at.
     ]
@@ -109,7 +109,7 @@ ViewSchema = collections.namedtuple(
 def extract_schemas_from_file(source_path):
     """Extract schemas from 'source_path'.
 
-    :returns: a list of ViewSchema objects on success, None if not schemas
+    :returns: a list of ViewSchema objects on success, None if no schemas
         could be extracted.
     """
     logging.info("Extracting schemas from %s", source_path)
@@ -134,7 +134,7 @@ def extract_schemas_from_file(source_path):
 def extract_schemas_from_source(source, filename='<unknown>'):
     """Extract schemas from 'source'.
 
-    The 'source' parameters must be a string, and should be valid python
+    The 'source' parameter must be a string, and should be valid python
     source.
 
     If 'source' is not valid python source, a SyntaxError will be raised.
@@ -206,8 +206,8 @@ def extract_schemas_from_source(source, filename='<unknown>'):
                 decorator_name = decorator.func.id
                 if decorator_name == 'validate_body':
                     # TODO: Check that nothing in the tree below
-                    # # decorator.args[0] is an instance of 'ast.Name', and
-                    # # print a nice error message if it is.
+                    # decorator.args[0] is an instance of 'ast.Name', and
+                    # print a nice error message if it is.
                     input_schema = ast.literal_eval(decorator.args[0])
                 if decorator_name == 'validate_output':
                     output_schema = ast.literal_eval(decorator.args[0])

--- a/acceptable/tests/test_build_doubles.py
+++ b/acceptable/tests/test_build_doubles.py
@@ -1,0 +1,309 @@
+# Copyright 2017 Canonical Ltd.  This software is licensed under the
+# GNU Lesser General Public License version 3 (see the file LICENSE).
+import ast
+import argparse
+import os.path
+from textwrap import dedent
+
+import fixtures
+from testtools import TestCase
+from testtools.matchers import (
+    Contains
+)
+
+from acceptable import _build_doubles
+
+
+class ExtractSchemasFromSourceTests(TestCase):
+
+    def test_invalid_source(self):
+        self.assertRaises(
+            SyntaxError,
+            _build_doubles.extract_schemas_from_source,
+            "This is not valid python source!"
+        )
+
+    def test_returns_empty_list_on_empty_source(self):
+        self.assertEqual([], _build_doubles.extract_schemas_from_source(''))
+
+    def test_ignores_undecorated_functions(self):
+        observed = _build_doubles.extract_schemas_from_source(
+            dedent('''
+            def my_view():
+                pass
+            '''))
+        self.assertEqual([], observed)
+
+    def test_can_extract_acceptable_view(self):
+        [schema] = _build_doubles.extract_schemas_from_source(
+            dedent('''
+
+            service = AcceptableService('vendor')
+
+            root_api = service.api('/', 'root')
+
+            @root_api.view(introduced_at='1.0')
+            def my_view():
+                pass
+            '''))
+
+        # TODO: This should be changed to be the view name, not the function
+        # name:
+        self.assertEqual('my_view', schema.view_name)
+        self.assertEqual('/', schema.url)
+        self.assertEqual('1.0', schema.version)
+        self.assertEqual(['GET'], schema.methods)
+        self.assertEqual(None, schema.input_schema)
+        self.assertEqual(None, schema.output_schema)
+
+    def test_can_extract_schema_with_input_schema(self):
+        [schema] = _build_doubles.extract_schemas_from_source(
+            dedent('''
+
+            service = AcceptableService('vendor')
+
+            root_api = service.api('/', 'root')
+
+            @root_api.view(introduced_at='1.0')
+            @validate_body({'type': 'object'})
+            def my_view():
+                pass
+            '''))
+
+        # TODO: This should be changed to be the view name, not the function
+        # name:
+        self.assertEqual('my_view', schema.view_name)
+        self.assertEqual('/', schema.url)
+        self.assertEqual('1.0', schema.version)
+        self.assertEqual(['GET'], schema.methods)
+        self.assertEqual({'type': 'object'}, schema.input_schema)
+        self.assertEqual(None, schema.output_schema)
+
+    def test_can_extract_schema_with_output_schema(self):
+        [schema] = _build_doubles.extract_schemas_from_source(
+            dedent('''
+
+            service = AcceptableService('vendor')
+
+            root_api = service.api('/', 'root')
+
+            @root_api.view(introduced_at='1.0')
+            @validate_output({'type': 'object'})
+            def my_view():
+                pass
+            '''))
+
+        # TODO: This should be changed to be the view name, not the function
+        # name:
+        self.assertEqual('my_view', schema.view_name)
+        self.assertEqual('/', schema.url)
+        self.assertEqual('1.0', schema.version)
+        self.assertEqual(['GET'], schema.methods)
+        self.assertEqual(None, schema.input_schema)
+        self.assertEqual({'type': 'object'}, schema.output_schema)
+
+    def test_can_extract_schema_with_methods(self):
+        [schema] = _build_doubles.extract_schemas_from_source(
+            dedent('''
+
+            service = AcceptableService('vendor')
+
+            root_api = service.api('/', 'root', methods=['POST', 'PUT'])
+
+            @root_api.view(introduced_at='1.0')
+            def my_view():
+                pass
+            '''))
+
+        # TODO: This should be changed to be the view name, not the function
+        # name:
+        self.assertEqual('my_view', schema.view_name)
+        self.assertEqual('/', schema.url)
+        self.assertEqual('1.0', schema.version)
+        self.assertEqual(['POST', 'PUT'], schema.methods)
+        self.assertEqual(None, schema.input_schema)
+        self.assertEqual(None, schema.output_schema)
+
+    def test_url_can_be_specified_with_kwarg(self):
+        [schema] = _build_doubles.extract_schemas_from_source(
+            dedent('''
+
+            service = AcceptableService('vendor')
+
+            root_api = service.api(url='/foo', view_name='root')
+
+            @root_api.view(introduced_at='1.0')
+            def my_view():
+                pass
+            '''))
+
+        # TODO: This should be changed to be the view name, not the function
+        # name:
+        self.assertEqual('my_view', schema.view_name)
+        self.assertEqual('/foo', schema.url)
+        self.assertEqual('1.0', schema.version)
+        self.assertEqual(['GET'], schema.methods)
+        self.assertEqual(None, schema.input_schema)
+        self.assertEqual(None, schema.output_schema)
+
+    def test_handles_other_assignments(self):
+        self.assertEqual(
+            [], _build_doubles.extract_schemas_from_source('foo = {}'))
+
+
+class ExtractSchemasFromFileTests(TestCase):
+
+    def test_logs_on_missing_file(self):
+        workdir = self.useFixture(fixtures.TempDir())
+        fake_logger = self.useFixture(fixtures.FakeLogger())
+
+        bad_path = os.path.join(workdir.path, 'path_does_not_exist')
+        result = _build_doubles.extract_schemas_from_file(bad_path)
+
+        self.assertIsNone(result)
+        self.assertThat(
+            fake_logger.output,
+            Contains('Extracting schemas from %s' % bad_path))
+        self.assertThat(
+            fake_logger.output,
+            Contains('Cannot extract schemas: No such file or directory'))
+
+    def test_logs_on_no_permissions(self):
+        workdir = self.useFixture(fixtures.TempDir())
+        fake_logger = self.useFixture(fixtures.FakeLogger())
+
+        bad_path = os.path.join(workdir.path, 'path_not_readable')
+        with open(bad_path, 'w') as f:
+            f.write("# You can't read me")
+        os.chmod(bad_path, 0)
+        result = _build_doubles.extract_schemas_from_file(bad_path)
+
+        self.assertIsNone(result)
+        self.assertThat(
+            fake_logger.output,
+            Contains('Extracting schemas from %s' % bad_path))
+        self.assertThat(
+            fake_logger.output,
+            Contains('Cannot extract schemas: Permission denied'))
+
+    def test_logs_on_syntax_error(self):
+        workdir = self.useFixture(fixtures.TempDir())
+        fake_logger = self.useFixture(fixtures.FakeLogger())
+
+        bad_path = os.path.join(workdir.path, 'foo.py')
+        with open(bad_path, 'w') as f:
+            f.write("not valid pyton")
+
+        result = _build_doubles.extract_schemas_from_file(bad_path)
+
+        self.assertIsNone(result)
+        self.assertThat(
+            fake_logger.output,
+            Contains('Extracting schemas from %s' % bad_path))
+        self.assertThat(
+            fake_logger.output,
+            Contains('Cannot extract schemas: invalid syntax (foo.py, line 1)')
+        )
+
+    def test_logs_on_schema_extraction(self):
+        workdir = self.useFixture(fixtures.TempDir())
+        fake_logger = self.useFixture(fixtures.FakeLogger())
+
+        good_path = os.path.join(workdir.path, 'my.py')
+        with open(good_path, 'w') as f:
+            f.write(dedent(
+                """
+                service = AcceptableService('vendor')
+
+                root_api = service.api('/', 'root')
+
+                @root_api.view(introduced_at='1.0')
+                def my_view():
+                    pass
+                """))
+        [schema] = _build_doubles.extract_schemas_from_file(good_path)
+
+        self.assertEqual('my_view', schema.view_name)
+        self.assertEqual('1.0', schema.version)
+        self.assertEqual(['GET'], schema.methods)
+        self.assertEqual(None, schema.input_schema)
+        self.assertEqual(None, schema.output_schema)
+
+        self.assertThat(
+            fake_logger.output,
+            Contains('Extracting schemas from %s' % good_path))
+        self.assertThat(
+            fake_logger.output,
+            Contains('Extracted 1 schema'))
+
+
+# To support testing, we need a version of ArgumentParser that doesn't call
+# sys.exit on error, but rather throws an exception, so we can catch that in
+# our tests:
+class SaneArgumentParser(argparse.ArgumentParser):
+
+    def error(self, message):
+        raise RuntimeError(message)
+
+
+class ParseArgsTests(TestCase):
+
+    def test_error_with_no_args(self):
+        self.assertRaises(
+            RuntimeError,
+            _build_doubles.parse_args,
+            [],
+            SaneArgumentParser
+        )
+
+    def test_scan_file_requires_file(self):
+        self.assertRaises(
+            RuntimeError,
+            _build_doubles.parse_args,
+            ['scan-file'],
+            SaneArgumentParser
+        )
+
+    def test_can_scan_file(self):
+        args = _build_doubles.parse_args(['scan-file', 'some-path'])
+        self.assertEqual('some-path', args.file)
+        self.assertEqual(_build_doubles.scan_file, args.func)
+
+    def test_build_requires_file(self):
+        self.assertRaises(
+            RuntimeError,
+            _build_doubles.parse_args,
+            ['build'],
+            SaneArgumentParser
+        )
+
+    def test_can_build(self):
+        args = _build_doubles.parse_args(['build', 'config-file'])
+        self.assertEqual('config-file', args.config_file)
+        self.assertEqual(_build_doubles.build_service_doubles, args.func)
+
+
+class RenderServiceDoubleTests(TestCase):
+
+    def assertIsValidPython(self, source):
+        try:
+            ast.parse(source)
+        except SyntaxError as e:
+            self.fail(str(e))
+
+    def test_renders_for_empty_schema_list(self):
+        source = _build_doubles.render_service_double('foo', [])
+        self.assertIsValidPython(source)
+
+    def test_renders_for_single_schema(self):
+        schema = _build_doubles.ViewSchema(
+            view_name='some_view',
+            version='1.3',
+            input_schema=None,
+            output_schema=None,
+            methods=['GET'],
+            url='/foo',
+        )
+        source = _build_doubles.render_service_double('foo', [schema])
+        self.assertIsValidPython(source)
+

--- a/setup.py
+++ b/setup.py
@@ -32,5 +32,10 @@ setup(
     packages=['acceptable'],
     install_requires=parse_requirements_file('requirements.txt'),
     test_suite='acceptable.tests',
-    tests_require=parse_requirements_file('requirements-dev.txt')
+    tests_require=parse_requirements_file('requirements-dev.txt'),
+    entry_points={
+          'console_scripts': [
+              'build_service_doubles = acceptable._build_doubles:main'
+          ]
+      },
 )


### PR DESCRIPTION
This branch adds the build_service_doubles entry point script. Most of the code is simply moved from snapstore-schemas, but parts have been adapted to be more testable.

There's some missing tests for the _build_doubles.py file, but I think the testing is adequate, given that this code isn't run in production ever.