### PR TITLE
Fix validation for payloads without Content-Type set.

### DIFF
--- a/acceptable/_validation.py
+++ b/acceptable/_validation.py
@@ -67,17 +67,12 @@ def validate_body(schema):
 
         @functools.wraps(fn)
         def wrapper(*args, **kwargs):
-            payload = request.get_json(silent=True, cache=True)
+            payload = request.get_json(silent=True, cache=True, force=True)
             # If flask can't parse the payload, we want to return a sensible
             # error message, so we try and parse it ourselves. Setting silent
             # to False above isn't good enough, as the generated error message
             # is not informative enough.
             if payload is None:
-                if not request.is_json:
-                    mimetype = request.headers.get('Content-Type')
-                    raise DataValidationError([
-                        "Expected JSON request body, but Content-Type is %s" %
-                        ('"{}"'.format(mimetype) if mimetype else "missing")])
                 try:
                     payload = json.loads(request.data.decode(request.charset))
                 except ValueError as e:

--- a/acceptable/tests/test_validation.py
+++ b/acceptable/tests/test_validation.py
@@ -106,39 +106,29 @@ class ValidateBodyTests(TestCase):
             StartsWith("Error decoding JSON request body: ")
         )
 
-    def test_raises_on_wrong_mimetype(self):
+    def test_validates_even__on_wrong_mimetype(self):
         app = self.useFixture(FlaskValidateBodyFixture({
             'type': 'object'
         }))
 
-        e = self.assertRaises(
-            DataValidationError,
-            app.client.post,
+        resp = app.client.post(
             '/',
             data='{}',
             headers={'Content-Type': 'text/plain'}
         )
-        self.assertEqual(
-            ['Expected JSON request body, but Content-Type is "text/plain"'],
-            e.error_list
-        )
+        self.assertEqual(200, resp.status_code)
 
-    def test_raises_on_missing_mimetype(self):
+    def test_validates_even_on_missing_mimetype(self):
         app = self.useFixture(FlaskValidateBodyFixture({
             'type': 'object'
         }))
 
-        e = self.assertRaises(
-            DataValidationError,
-            app.client.post,
+        resp = app.client.post(
             '/',
             data='{}',
             headers={}
         )
-        self.assertEqual(
-            ["Expected JSON request body, but Content-Type is missing"],
-            e.error_list
-        )
+        self.assertEqual(200, resp.status_code)
 
 
 class ValidateOutputTests(TestCase):


### PR DESCRIPTION
Make validate_body work even when the Content-Type header is not set to 'application/json'.