### PR TITLE
Add homepage to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     description='API version negotiation for flask-based web services.',
     author='Canonical Online Services',
     author_email='online-services@lists.canonical.com',
+    url='https://github.com/canonical-ols/acceptable',
     license='LGPLv3',
     packages=['acceptable'],
     install_requires=parse_requirements_file('requirements.txt'),


### PR DESCRIPTION
After finding `acceptable` on PyPi I struggled to find where it lived. Let's fix that by adding a URL