### PR TITLE
Allow specifying an HTTP status for ServiceMock

### DIFF
--- a/acceptable/_doubles.py
+++ b/acceptable/_doubles.py
@@ -49,7 +49,7 @@ class ServiceMock(Fixture):
     _requests_mock = None
 
     def __init__(self, service, methods, url, input_schema, output_schema,
-                 output):
+                 output, output_status=200):
         super().__init__()
         self._service = service
         self._methods = methods
@@ -57,6 +57,7 @@ class ServiceMock(Fixture):
         self._input_schema = input_schema
         self._output_schema = output_schema
         self._output = output
+        self._output_status = output_status
 
     def _setUp(self):
         if self._output_schema:
@@ -97,7 +98,7 @@ class ServiceMock(Fixture):
                     )
             # TODO: Do we need to support more than just json responses?
             return (
-                200,
+                self._output_status,
                 {"Content-Type": "application/json"},
                 json.dumps(self._output)
             )

--- a/acceptable/tests/test_doubles.py
+++ b/acceptable/tests/test_doubles.py
@@ -210,6 +210,25 @@ class ServiceMockTests(TestCase):
             requests.patch("http://localhost:1234/foo", json={}).status_code
         )
 
+    def test_mock_output_status(self):
+        double = ServiceMock(
+            service='foo',
+            methods=['POST'],
+            url='/foo',
+            input_schema={'type': 'object'},
+            output_schema={'type': 'array'},
+            output=[],
+            output_status=201
+        )
+        set_service_locations(dict(foo="http://localhost:1234/"))
+
+        self.useFixture(double)
+
+        self.assertEqual(
+            201,
+            requests.post("http://localhost:1234/foo", json={}).status_code
+        )
+
     def test_service_mock(self):
         double_factory = service_mock(
             service='foo',


### PR DESCRIPTION
For example, this makes it easier to test functions that call endpoints
that are expected to return 201.