### PR TITLE
Remove support for content negotiation.

### DIFF
--- a/acceptable/_service.py
+++ b/acceptable/_service.py
@@ -1,248 +1,91 @@
 # Copyright 2017 Canonical Ltd.  This software is licensed under the
 # GNU Lesser General Public License version 3 (see the file LICENSE).
 
-"""acceptable - version Flask views using the Accept header."""
-import functools
-import re
-
-from flask import request
-from werkzeug.exceptions import NotAcceptable
+"""acceptable - Programatic API Metadata for Flask apps."""
 
 
 class AcceptableService:
-
     """Main entry point for a service using acceptable to manage API versions.
 
-    This class manages service-wide options such as the vendor identifier. An
-    instance of this class is required to create an API endpoint.
+    This class manages a set of API endpoints for a given service. An instance
+    of this class is required to create an API endpoint.
     """
+    NAME_ALREADY = 'API {} is already registered in service {}'
+    URL_ALREADY = 'URL {} {} is already in service {}'
 
-    def __init__(self, vendor, flask_app=None):
+    def __init__(self, name):
         """Create an instance of AcceptableService.
 
-        :param vendor: The vendor string. Must not contain spaces or
-            punctuation.
-        :param flask_app: an instance of flask.Flask. If not specified, the
-            'initialise' method must be called before any of the API endpoints
-            will be registered in the Flask URL route.
-        :raises ValueError: If the vendor string contains spaces or
-            punctuation.
-        :raises TypeError: If the vendor string is something other than a
+        :param name: The service name.
+        :raises TypeError: If the name string is something other than a
             string.
         """
-        if not isinstance(vendor, str):
+        if not isinstance(name, str):
             raise TypeError(
-                "vendor must be a string, not %s" % type(vendor).__name__)
-        if not vendor.isalpha():
-            raise ValueError("vendor identifier must consist of alphanumeric "
-                             "characters only.")
-        self.vendor = vendor
-        self._flask_app = flask_app
-        self._late_registrations = []
-        self._completed_registrations = []
+                "name must be a string, not %s" % type(name).__name__)
+        self.name = name
+        self.apis = {}
+        self.urls = set()
 
     def api(self, url, name, **options):
         """Add an API to the service.
 
         :param url: This is the url that the API should be registered at.
-        :param name: This is the name the URL route should be registered in
-            flask with.
+        :param name: This is the name of the api, and will be registered with
+            flask apps under.
 
         Other keyword arguments may be used, and they will be passed to the
-        underlying flask application. Of particular interest is the 'methods'
-        keyword argument, which can be used to specify the HTTP method the URL
-        will be added for.
+        flask application when initialised. Of particular interest is the
+        'methods' keyword argument, which can be used to specify the HTTP
+        method the URL will be added for.
         """
-        used_names = [
-            i[1] for i in
-            self._late_registrations + self._completed_registrations]
-        if name in used_names:
-            raise ValueError(
-                "The name '%s' has already been registered for an API."
-                % name)
-        api = AcceptableAPI(self, name)
-        if self._flask_app is None:
-            self._late_registrations.append((url, name, api, options))
-        else:
-            self._flask_app.add_url_rule(url, name, view_func=api, **options)
-            self._completed_registrations.append((url, name, api, options))
+        assert name not in self.apis, self.NAME_ALREADY.format(name, self.name)
+        methods = tuple(options.get('methods', ('GET',)))
+        assert (url, methods) not in self.urls, self.URL_ALREADY.format(
+            '|'.join(methods), url, self.name)
+
+        api = AcceptableAPI(self, name, url, options)
+        self.apis[name] = api
+        self.urls.add((url, methods))
         return api
 
-    def initialise(self, flask_app):
-        """Initialise the API.
+    def bind(self, flask_app):
+        """Bind the service API urls to a flask app."""
+        for name, api in self.apis.items():
+            # only bind APIs that have views associated with them
+            if api.view_fn is None:
+                continue
+            if name not in flask_app.view_functions:
+                flask_app.add_url_rule(
+                    api.url, name, view_func=api.view_fn, **api.options)
 
-        This method initialises the API (for the cases where no flask
-        application was passed to AcceptableService.__init__) or
-        re-initialises the API (for the case where you want to bind the API
-        to a new/different flask application). In the latter case the old
-        flask application will still be bound to the API views - it is the
-        callers responsibility to destroy it.
-
-        """
-        if flask_app == self._flask_app:
-            return  # already initialised to this flask application.
-        if self._flask_app is not None:
-            # we're re-binding the API to a new flask app. Iterate over the
-            # already completed registrations for the current app. There should
-            # never be late registrations left at this point:
-            assert self._late_registrations == [], "Late registrations should \
-                not exist when rebinding API to a new flask application!"
-            api_views_to_register = self._completed_registrations
-        else:
-            # This is the first (late) initialisation, binding to a new flask
-            # application. Completed registrations should be empty at this
-            # point:
-            assert self._completed_registrations == [], "Completed \
-                registrations should be empty when binding to the first flask \
-                application!"
-            api_views_to_register = self._late_registrations
-        self._flask_app = flask_app
-        completed_registrations = []
-        while api_views_to_register:
-            url, name, api, options = api_views_to_register.pop()
-            self._flask_app.add_url_rule(url, name, view_func=api, **options)
-            completed_registrations.append((url, name, api, options))
-        self._completed_registrations = completed_registrations
+    # b/w compat
+    initialise = bind
 
 
 class AcceptableAPI:
+    """Metadata abount an api endpoint."""
 
-    def __init__(self, service, name):
-        self.endpoint_map = EndpointMap()
+    def __init__(self, service, name, url, options):
         self.service = service
-        # make an AcceptableAPI instance look more like a regular function,
-        # which some extensions expect
-        self.__name__ = name
+        self.name = name
+        self.url = url
+        self.options = options
+        self.introduced_at = None
+        self.view_fn = None
 
-    def __call__(self, *args, **kwargs):
-        # find the correct version / tagged view and call it.
-        version, flag = parse_accept_headers(
-            self.service.vendor, request.accept_mimetypes.values())
-        if version is None:
-            version = EndpointMap.DefaultView
-        view = self.endpoint_map.get_view(version, flag)
-        if view:
-            return view(*args, **kwargs)
-        else:
-            description = "Could not find view for version '%s'" % version
-            if flag is not None:
-                description += " and flag '%s'" % flag
-            raise NotAcceptable(description)
-
-    def view(self, introduced_at, flag=None):
-        assert isinstance(introduced_at, str)
-        assert isinstance(flag, (str, type(None)))
+    def view(self, introduced_at):
+        assert self.view_fn is None, 'api already has view registered'
 
         def wrapper(fn):
-            self.register_view(introduced_at, flag, fn)
-
-            @functools.wraps(fn)
-            def indirection(*args, **kwargs):
-                return self(*args, **kwargs)
-            return indirection
+            self.register_view(introduced_at, fn)
+            return fn
         return wrapper
 
-    def register_view(self, introduced_at, flag, view_fn):
-        assert isinstance(introduced_at, str)
-        assert isinstance(flag, (str, type(None)))
-        self.endpoint_map.add_view(introduced_at, flag, view_fn)
-
-
-def parse_accept_headers(vendor, header_values):
-    """Parse the Accept header values, returning the client's requested API
-    version and API flag, if any.
-
-    :param vendor: The vendor identifier for the current service.
-    :param header_values: A list of header values to inspect.
-    Returns a 2-tuple of version, tag.
-
-    If the client requested no tag, the second parameter will be None.
-    If the client does not specify a version, or the version is poorly
-        formatted this function will return (None, None)
-    """
-    for accept_value in header_values:
-        m = re.match(
-            r'application/vnd.%s.(\d+\.\d+)(\+?.*)' % vendor,
-            accept_value
-        )
-        if m:
-            version, tags = m.groups()
-            tags = tags.lstrip('+') if tags else None
-            return (version, tags)
-    return None, None
-
-
-class EndpointMap:
-
-    """Keep track of which views have been registered, and select an
-    appropriate view based on a client's request.
-
-    Each view is selected based on three attributes:
-     * The flag the view requires.
-     * The version the view was added in.
-
-    Of these three attributes, the first two are matched literally, but the
-    third is slightly more complex: a view added in '1.0' is still available
-    in '1.1' even if it wasn't registered at that version.
-
-    This class attaches no checks to the 'view' objects that it stores: It only
-    applies semantic meaning to the 'keys' listed above.
-    """
-
-    # The DefaultView sentinel represents whatever is the default version of
-    # a view:
-    DefaultView = object()
-
-    def __init__(self):
-        self._map = {}
-
-    def add_view(self, version, flag, view):
-        _check_version_and_flag_types(version, flag)
-
-        if flag not in self._map:
-            self._map[flag] = {version: view}
+    def register_view(self, introduced_at, view_fn):
+        # legacy support
+        if introduced_at == '1.0':
+            self.introduced_at = 1
         else:
-            self._map[flag][version] = view
-
-    def get_view(self, version, flag=None):
-        _check_version_and_flag_types(version, flag)
-
-        versionmap = self._map.get(flag, {})
-        # An exact match is easy:
-        if version == EndpointMap.DefaultView:
-            latest_version = sorted(versionmap.keys(), reverse=True)[0]
-            return versionmap[latest_version]
-        if version in versionmap:
-            return versionmap[version]
-        # no exact match found, iterate over available versions
-        # until a view is found that's lower than the requested
-        # version.
-        for available_version in sorted(versionmap.keys(), reverse=True):
-            if available_version < version:
-                return versionmap[available_version]
-        # If we can't find a view with the flagt present, consider views
-        # without the view as a fallback:
-        if flag is not None:
-            return self.get_view(version, flag=None)
-        # Client perhaps asked for an older version than we have
-        # in our map - return None:
-        return None
-
-
-def _check_version_and_flag_types(version, flag):
-    if not isinstance(flag, (str, type(None))):
-        raise TypeError(
-            "Flag must be a string or None, not %s" % type(flag).__name__)
-    if version != EndpointMap.DefaultView:
-        if not isinstance(version, str):
-            raise TypeError(
-                "Version must be a string, not %s" % type(version).__name__)
-        try:
-            major, minor = version.split('.')
-        except ValueError:
-            raise ValueError("Version must be in the format <major>.<minor>")
-        else:
-            if not major.isdecimal():
-                raise ValueError("Major version number is not an integer.")
-            if not minor.isdecimal():
-                raise ValueError("Minor version number is not an integer.")
+            self.introduced_at = int(introduced_at)
+        self.view_fn = view_fn

--- a/acceptable/_service.py
+++ b/acceptable/_service.py
@@ -10,8 +10,6 @@ class AcceptableService:
     This class manages a set of API endpoints for a given service. An instance
     of this class is required to create an API endpoint.
     """
-    NAME_ALREADY = 'API {} is already registered in service {}'
-    URL_ALREADY = 'URL {} {} is already in service {}'
 
     def __init__(self, name):
         """Create an instance of AcceptableService.
@@ -39,10 +37,15 @@ class AcceptableService:
         'methods' keyword argument, which can be used to specify the HTTP
         method the URL will be added for.
         """
-        assert name not in self.apis, self.NAME_ALREADY.format(name, self.name)
+        assert name not in self.apis, (
+            'API {} is already registered in service {}'.format(
+                name, self.name)
+        )
         methods = tuple(options.get('methods', ('GET',)))
-        assert (url, methods) not in self.urls, self.URL_ALREADY.format(
-            '|'.join(methods), url, self.name)
+        assert (url, methods) not in self.urls, (
+            'URL {} {} is already in service {}'.format(
+                '|'.join(methods), url, self.name)
+        )
 
         api = AcceptableAPI(self, name, url, options)
         self.apis[name] = api

--- a/acceptable/tests/test_service.py
+++ b/acceptable/tests/test_service.py
@@ -1,22 +1,16 @@
 # Copyright 2017 Canonical Ltd.  This software is licensed under the
 # GNU Lesser General Public License version 3 (see the file LICENSE).
 
-from operator import methodcaller
-
 from fixtures import Fixture
 from flask import Flask
-from testscenarios import TestWithScenarios
 from testtools import TestCase
 from testtools.matchers import (
-    Contains,
     Equals,
     Matcher,
 )
 
 from acceptable._service import (
     AcceptableService,
-    EndpointMap,
-    parse_accept_headers,
 )
 
 
@@ -25,92 +19,29 @@ class AcceptableServiceTestCase(TestCase):
     def test_raises_TypeError_on_construction(self):
         self.assertRaisesRegex(
             TypeError,
-            "vendor must be a string, not object",
+            "name must be a string, not object",
             AcceptableService,
-            object(), object()
-        )
-
-    def test_raises_ValueError_on_construction(self):
-        self.assertRaisesRegex(
-            ValueError,
-            "vendor identifier must consist of alphanumeric "
-            "characters only.",
-            AcceptableService,
-            "vendor.foo", object()
+            object(),
         )
 
     def test_can_register_url_route(self):
         def view():
             return "test view", 200
 
-        app = Flask(__name__)
-        service = AcceptableService('vendor', app)
+        service = AcceptableService('service')
         api = service.api('/foo', 'foo_api')
-        api.register_view('1.0', None, view)
+        api.register_view('1.0', view)
+
+        app = Flask(__name__)
+        service.bind(app)
 
         client = app.test_client()
         resp = client.get('/foo')
 
         self.assertThat(resp, IsResponse('test view'))
 
-    def test_can_register_url_route_with_two_phase_registration(self):
-        def view():
-            return "test view", 200
 
-        service = AcceptableService('vendor')
-        api = service.api('/foo', 'foo_api')
-        api.register_view('1.0', None, view)
-
-        app = Flask(__name__)
-        service.initialise(app)
-
-        client = app.test_client()
-        resp = client.get('/foo')
-
-        self.assertThat(resp, IsResponse('test view'))
-
-    def test_can_rebind_api_to_second_flask_application(self):
-        def view():
-            return "test view", 200
-
-        service = AcceptableService('vendor')
-        api = service.api('/foo', 'foo_api')
-        api.register_view('1.0', None, view)
-
-        app1 = Flask(__name__)
-        app2 = Flask(__name__)
-        service.initialise(app1)
-
-        client = app1.test_client()
-        resp = client.get('/foo')
-
-        self.assertThat(resp, IsResponse('test view'))
-
-        service.initialise(app2)
-        client = app2.test_client()
-        resp = client.get('/foo')
-
-        self.assertThat(resp, IsResponse('test view'))
-
-    def test_rebinding_to_existing_application_is_a_noop(self):
-        def view():
-            return "test view", 200
-
-        service = AcceptableService('vendor')
-        api = service.api('/foo', 'foo_api')
-        api.register_view('1.0', None, view)
-
-        app1 = Flask(__name__)
-        service.initialise(app1)
-        service.initialise(app1)
-
-        client = app1.test_client()
-        resp = client.get('/foo')
-
-        self.assertThat(resp, IsResponse('test view'))
-
-
-class SimpleAPIServiceFixture(Fixture):
+class ServiceFixture(Fixture):
     """A reusable fixture that sets up several API endpoints.
 
     This fixture creates a simple set of API endpoints with a mix of different
@@ -119,106 +50,24 @@ class SimpleAPIServiceFixture(Fixture):
     """
 
     def _setUp(self):
-        self.flask_app = Flask(__name__)
-        self.service = AcceptableService('vendor', self.flask_app)
-
-        # The /foo API is POST only, and contains three different versioned
-        # endpoints:
+        self.service = AcceptableService('service')
         foo_api = self.service.api('/foo', 'foo_api', methods=['POST'])
-        foo_api.register_view('1.0', None, self.foo_v10)
-        foo_api.register_view('1.1', None, self.foo_v11)
-        foo_api.register_view('1.3', None, self.foo_v13)
-        foo_api.register_view('1.5', None, self.foo_v15)
+        foo_api.register_view('1.0', self.foo)
 
-        # The /flagged API is GET only, and has some API flags set:
-        flagged_api = self.service.api('/flagged', 'flagged', methods=['GET'])
-        flagged_api.register_view('1.3', None, self.flagged_v13)
-        flagged_api.register_view('1.4', 'feature1', self.flagged_v14_feature1)
-        flagged_api.register_view('1.4', 'feature2', self.flagged_v14_feature2)
+    def bind(self, app=None):
+        if app is None:
+            app = Flask(__name__)
+        self.service.bind(app)
+        return app
 
-    def foo_v10(self):
-        return "Foo version 1.0", 200
-
-    def foo_v11(self):
-        return "Foo version 1.1", 200
-
-    def foo_v13(self):
-        return "Foo version 1.3", 200
-
-    def foo_v15(self):
-        return "Foo version 1.5", 200
-
-    def flagged_v13(self):
-        return "Flagged version 1.3", 200
-
-    def flagged_v14_feature1(self):
-        return "Flagged version 1.4 with feature1", 200
-
-    def flagged_v14_feature2(self):
-        return "Flagged version 1.4 with feature2", 200
+    def foo(self):
+        return "foo", 200
 
 
 class AcceptableAPITestCase(TestCase):
 
-    def test_default_view_is_latest_version(self):
-        fixture = self.useFixture(SimpleAPIServiceFixture())
-        client = fixture.flask_app.test_client()
-        resp = client.post('/foo')
-
-        self.assertThat(resp, IsResponse("Foo version 1.5"))
-
-    def test_can_select_specific_version(self):
-        fixture = self.useFixture(SimpleAPIServiceFixture())
-        client = fixture.flask_app.test_client()
-        resp = client.post(
-            '/foo',
-            headers={'Accept': 'application/vnd.vendor.1.1'})
-
-        self.assertThat(resp, IsResponse("Foo version 1.1"))
-
-    def test_versions_are_downgraded(self):
-        # Ask for version 1.2, but since it doesn't exist we'll
-        # get the next oldest version instead.
-        fixture = self.useFixture(SimpleAPIServiceFixture())
-        client = fixture.flask_app.test_client()
-        resp = client.post(
-            '/foo',
-            headers={'Accept': 'application/vnd.vendor.1.2'})
-
-        self.assertThat(resp, IsResponse("Foo version 1.1"))
-
-    def test_get_unflagged_view_by_default(self):
-        fixture = self.useFixture(SimpleAPIServiceFixture())
-        client = fixture.flask_app.test_client()
-        resp = client.get('/flagged')
-
-        self.assertThat(resp, IsResponse("Flagged version 1.3"))
-
-    def test_can_select_flagged_view(self):
-        fixture = self.useFixture(SimpleAPIServiceFixture())
-        client = fixture.flask_app.test_client()
-        resp = client.get(
-            '/flagged',
-            headers={'Accept': 'application/vnd.vendor.1.4+feature1'})
-
-        self.assertThat(resp, IsResponse("Flagged version 1.4 with feature1"))
-
-    def test_no_acceptable_version(self):
-        fixture = self.useFixture(SimpleAPIServiceFixture())
-        client = fixture.flask_app.test_client()
-        resp = client.get(
-            '/flagged',
-            headers={'Accept': 'application/vnd.vendor.1.0+foo'})
-
-        self.assertThat(
-            resp,
-            IsResponse(
-                Contains(
-                    "Could not find view for version '1.0' and flag 'foo'"),
-                406))
-
     def test_view_decorator_works(self):
-        fixture = self.useFixture(SimpleAPIServiceFixture())
+        fixture = self.useFixture(ServiceFixture())
 
         new_api = fixture.service.api('/new', 'blah')
 
@@ -226,263 +75,65 @@ class AcceptableAPITestCase(TestCase):
         def new_view():
             return "new view", 200
 
-        client = fixture.flask_app.test_client()
+        app = fixture.bind()
+
+        client = app.test_client()
         resp = client.get('/new')
 
         self.assertThat(resp, IsResponse("new view"))
-        view = fixture.flask_app.view_functions['blah']
-        self.assertEqual(view.__name__, 'blah')
+        view = app.view_functions['blah']
+        self.assertEqual(view.__name__, 'new_view')
 
     def test_can_still_call_view_directly(self):
-        fixture = self.useFixture(SimpleAPIServiceFixture())
+        fixture = self.useFixture(ServiceFixture())
 
         new_api = fixture.service.api('/new', 'namegoeshere')
 
         @new_api.view(introduced_at='1.0')
         def new_view():
             return "new view", 200
-        with fixture.flask_app.test_request_context('/new'):
+
+        app = fixture.bind()
+        with app.test_request_context('/new'):
             content, status = new_view()
+
         self.assertEqual(content, "new view")
         self.assertEqual(status, 200)
 
-    def test_can_reuse_url_with_different_method(self):
-        fixture = self.useFixture(SimpleAPIServiceFixture())
+    def test_cannot_duplicate_name(self):
+        fixture = self.useFixture(ServiceFixture())
 
-        # /foo already exists as a POST endpoint, we should be able to
-        # create another /foo API with a GET endpoint.
-        foo_get_api = fixture.service.api('/foo', 'foo', methods=['GET'])
-
-        @foo_get_api.view(introduced_at='1.0')
-        def get_foo():
-            return "Foo GET API"
-
-        client = fixture.flask_app.test_client()
-        resp_get = client.get('/foo')
-
-        self.assertThat(resp_get, IsResponse("Foo GET API"))
-
-    def test_view_attributes_are_preserved(self):
-        fixture = self.useFixture(SimpleAPIServiceFixture())
-
-        new_api = fixture.service.api('/new', 'new')
-
-        def my_decorator(fn):
-            fn.foo = 'bar'
-            return fn
-
-        @new_api.view(introduced_at='1.0')
-        @my_decorator
-        def new_view():
-            return "new view", 200
-
-        self.assertEqual(new_view.foo, 'bar')
-
-    def test_cannot_duplicate_api_names(self):
-        fixture = self.useFixture(SimpleAPIServiceFixture())
-
-        fixture.service.api('/new', 'some name here')
-        e = self.assertRaises(
-            ValueError,
+        self.assertRaises(
+            AssertionError,
             fixture.service.api,
-            '/another',
-            'some name here'
-        )
-        self.assertEqual(
-            "The name 'some name here' has already been registered for an "
-            "API.", str(e))
-
-    def test_can_expose_same_view_in_multiple_apis(self):
-        flask_app = Flask(__name__)
-        service = AcceptableService('vendor', flask_app)
-
-        api1 = service.api('/foo1', 'foo1')
-        api2 = service.api('/foo2', 'foo2')
-
-        @api1.view(introduced_at='1.0')
-        @api2.view(introduced_at='1.0')
-        def get_foo():
-            return "Foo API"
-
-        client = flask_app.test_client()
-
-        resp1 = client.get('/foo1')
-        resp2 = client.get('/foo2')
-
-        self.assertThat(resp1, IsResponse("Foo API"))
-        self.assertThat(resp2, IsResponse("Foo API"))
-
-
-
-class EndpointMapTestCase(TestCase):
-
-    def test_simple_match(self):
-        # Test an exact match without flags
-        m = EndpointMap()
-        view = object()
-
-        m.add_view('1.0', None, view)
-
-        self.assertEqual(view, m.get_view('1.0'))
-
-    def test_version_downgrade(self):
-        # If we can't satisfy the version requirement we'll return an
-        # older view.
-        m = EndpointMap()
-        view = object()
-
-        m.add_view('1.2', None, view)
-
-        self.assertEqual(view, m.get_view('1.3'))
-
-    def test_flagged_view(self):
-        # Test an exact match with flags:
-        m = EndpointMap()
-        normal_view = object()
-        flagged_view = object()
-
-        m.add_view('1.0', None, normal_view)
-        m.add_view('1.0', 'flag', flagged_view)
-
-        self.assertEqual(normal_view, m.get_view('1.0'))
-        self.assertEqual(flagged_view, m.get_view('1.0', 'flag'))
-
-    def test_flagged_downgrade(self):
-        # If we can't satisfy the flag request we'll ignore it:
-        m = EndpointMap()
-        normal_view = object()
-
-        m.add_view('1.0', None, normal_view)
-
-        self.assertEqual(normal_view, m.get_view('1.0', 'flag'))
-
-    def test_does_not_version_upgrade(self):
-        # if we can't satisfy the version request we won't upgrade to
-        # an older version
-        m = EndpointMap()
-        view = object()
-
-        m.add_view('1.2', None, view)
-
-        self.assertEqual(None, m.get_view('1.1'))
-
-    def test_version_downgrade_is_smallest_increment(self):
-        # If we can't satisfy the exact version requested, give the
-        # client the smallest decrement in version possible.
-        m = EndpointMap()
-        view11 = object()
-        view12 = object()
-        view13 = object()
-
-        m.add_view('1.1', None, view11)
-        m.add_view('1.2', None, view12)
-        m.add_view('1.3', None, view13)
-
-        self.assertEqual(view13, m.get_view('1.4'))
-
-
-class EndpointMapTypeCheckingTests(TestWithScenarios):
-
-    scenarios = [
-        ('bad version type', {
-            'args': (True, None, None),
-            'exception': TypeError,
-            'expected_error': "Version must be a string, not bool",
-        }),
-        ('bad flag type', {
-            'args': ('1.0', object(), None),
-            'exception': TypeError,
-            'expected_error': "Flag must be a string or None, not object",
-        }),
-        ('version with too many components', {
-            'args': ('1.0.0', None, None),
-            'exception': ValueError,
-            'expected_error': "Version must be in the format "
-                              "<major>.<minor>",
-        }),
-        ('bad major version', {
-            'args': ('one.2', None, None),
-            'exception': ValueError,
-            'expected_error': "Major version number is not an integer",
-        }),
-        ('bad minor version', {
-            'args': ('1.two', None, None),
-            'exception': ValueError,
-            'expected_error': "Minor version number is not an integer",
-        }),
-    ]
-
-    def test_add_view_type_checking(self):
-        m = EndpointMap()
-        self.assertRaisesRegex(
-            self.exception,
-            self.expected_error,
-            methodcaller('add_view', *self.args),
-            m
+            '/bar',
+            'foo_api',
         )
 
-    def test_get_view_type_checking(self):
-        # get view doesn't accept the view parameter, so trim it from the
-        # argument list:
-        args = self.args[:-1]
-        m = EndpointMap()
-        self.assertRaisesRegex(
-            self.exception,
-            self.expected_error,
-            methodcaller('get_view', *args),
-            m
+    def test_cannot_duplicate_url_and_method(self):
+        fixture = self.useFixture(ServiceFixture())
+        self.assertRaises(
+            AssertionError,
+            fixture.service.api,
+            '/foo',
+            'bar',
+            methods=['POST'],
         )
 
+    def test_can_duplicate_url_different_method(self):
+        fixture = self.useFixture(ServiceFixture())
 
-class AcceptHeaderParseTests(TestWithScenarios):
+        alt_api = fixture.service.api('/foo', 'foo_alt', methods=['GET'])
 
-    scenarios = [
-        ('No match', {
-            'vendor': '',
-            'headers': ['*/*'],
-            'expected': (None, None),
-        }),
-        ('Mismatched vendor', {
-            'vendor': 'foo',
-            'headers': ['application/vnd.bar.1.2'],
-            'expected': (None, None),
-        }),
-        ('Normal mimetype', {
-            'vendor': 'foo',
-            'headers': ['text/html'],
-            'expected': (None, None),
-        }),
-        ('invalid version format', {
-            'vendor': 'foo',
-            'headers': ['application/vnd.foo.version1'],
-            'expected': (None, None),
-        }),
-        ('Version with no flag', {
-            'vendor': 'foo',
-            'headers': ['application/vnd.foo.1.2'],
-            'expected': ('1.2', None),
-        }),
-        ('Version with flag', {
-            'vendor': 'foo',
-            'headers': ['application/vnd.foo.1.3+feature1'],
-            'expected': ('1.3', 'feature1'),
-        }),
-        ('match after normal mimetype', {
-            'vendor': 'foo',
-            'headers': ['text/html', 'application/vnd.foo.1.3+feature1'],
-            'expected': ('1.3', 'feature1'),
-        }),
-        ('match after vendor mismatch mimetype', {
-            'vendor': 'foo',
-            'headers': ['application/vnd.bar.1.2',
-                        'application/vnd.foo.1.3+feature1'],
-            'expected': ('1.3', 'feature1'),
-        }),
-    ]
+        @alt_api.view(introduced_at='1.0')
+        def foo_alt():
+            return "alt foo", 200
 
-    def test_header_parsing(self):
-        observed = parse_accept_headers(self.vendor, self.headers)
-        self.assertEqual(observed, self.expected)
+        app = fixture.bind()
+        client = app.test_client()
+        resp = client.get('/foo')
+
+        self.assertThat(resp, IsResponse("alt foo"))
 
 
 class IsResponse(Matcher):

--- a/acceptable/tests/test_service.py
+++ b/acceptable/tests/test_service.py
@@ -66,12 +66,23 @@ class ServiceFixture(Fixture):
 
 class AcceptableAPITestCase(TestCase):
 
-    def test_view_decorator_works(self):
+    def test_acceptable_api_declaration_works(self):
+        fixture = self.useFixture(ServiceFixture())
+
+        api = fixture.service.api('/new', 'blah')
+
+        self.assertEqual(api.url, '/new')
+        self.assertEqual(api.options, {})
+        self.assertEqual(api.name, 'blah')
+
+        self.assertEqual(api, fixture.service.apis['blah'])
+
+    def test_view_decorator_and_bind_works(self):
         fixture = self.useFixture(ServiceFixture())
 
         new_api = fixture.service.api('/new', 'blah')
 
-        @new_api.view(introduced_at='1.0')
+        @new_api.view(introduced_at=1)
         def new_view():
             return "new view", 200
 
@@ -84,12 +95,36 @@ class AcceptableAPITestCase(TestCase):
         view = app.view_functions['blah']
         self.assertEqual(view.__name__, 'new_view')
 
+    def test_view_introduced_at_string(self):
+        fixture = self.useFixture(ServiceFixture())
+
+        new_api = fixture.service.api('/new', 'blah')
+        self.assertEqual(new_api.introduced_at, None)
+
+        @new_api.view(introduced_at='1')
+        def new_view():
+            return "new view", 200
+
+        self.assertEqual(new_api.introduced_at, 1)
+
+    def test_view_introduced_at_1_0_string(self):
+        fixture = self.useFixture(ServiceFixture())
+
+        new_api = fixture.service.api('/new', 'blah')
+        self.assertEqual(new_api.introduced_at, None)
+
+        @new_api.view(introduced_at='1.0')
+        def new_view():
+            return "new view", 200
+
+        self.assertEqual(new_api.introduced_at, 1)
+
     def test_can_still_call_view_directly(self):
         fixture = self.useFixture(ServiceFixture())
 
         new_api = fixture.service.api('/new', 'namegoeshere')
 
-        @new_api.view(introduced_at='1.0')
+        @new_api.view(introduced_at=1)
         def new_view():
             return "new view", 200
 
@@ -125,7 +160,7 @@ class AcceptableAPITestCase(TestCase):
 
         alt_api = fixture.service.api('/foo', 'foo_alt', methods=['GET'])
 
-        @alt_api.view(introduced_at='1.0')
+        @alt_api.view(introduced_at=1)
         def foo_alt():
             return "alt foo", 200
 


### PR DESCRIPTION
This removes a lot of complexity from AcceptableService, as paves the
way for gathering metadata by import rather than AST.

This is an internal refactor, and preserves the existing API, but does
alter behaviour: you can now only have one view per url/methods pair.