### PR TITLE
Importable metadata

### DIFF
--- a/acceptable/_service.py
+++ b/acceptable/_service.py
@@ -10,6 +10,8 @@ class AcceptableService:
     This class manages a set of API endpoints for a given service. An instance
     of this class is required to create an API endpoint.
     """
+    NAME_ALREADY = 'API {} is already registered in service {}'
+    URL_ALREADY = 'URL {} {} is already in service {}'
 
     def __init__(self, name):
         """Create an instance of AcceptableService.

--- a/acceptable/_service.py
+++ b/acceptable/_service.py
@@ -12,9 +12,6 @@ class APIMetadata:
     and verify uniqueness.
     """
 
-    NAME_ALREADY = 'API {} is already registered in service {}'
-    URL_ALREADY = 'URL {} {} is already in service {}'
-
     def __init__(self):
         self.services = {}
         self.api_names = set()
@@ -25,11 +22,15 @@ class APIMetadata:
             self.services[name, group] = {}
 
     def register_api(self, name, group, api):
-        assert api.name not in self.api_names, self.NAME_ALREADY.format(
-            api.name, name)
+        assert api.name not in self.api_names, (
+            'API {} is already registered in service {}'.format(
+                api.name, name)
+        )
         url_key = (api.url, api.methods)
-        assert url_key not in self.urls, self.URL_ALREADY.format(
-            '|'.join(api.methods), api.url, name)
+        assert url_key not in self.urls, (
+            'URL {} {} is already in service {}'.format(
+                '|'.join(api.methods), api.url, name)
+        )
         self.api_names.add(api.name)
         self.urls.add((api.url, api.methods))
         self.services[name, group][api.name] = api
@@ -94,16 +95,6 @@ class AcceptableService:
         'methods' keyword argument, which can be used to specify the HTTP
         method the URL will be added for.
         """
-        assert name not in self.apis, (
-            'API {} is already registered in service {}'.format(
-                name, self.name)
-        )
-        methods = tuple(options.get('methods', ('GET',)))
-        assert (url, methods) not in self.urls, (
-            'URL {} {} is already in service {}'.format(
-                '|'.join(methods), url, self.name)
-        )
-
         api = AcceptableAPI(name, url, introduced_at, options)
         self.metadata.register_api(self.name, self.group, api)
         return api

--- a/acceptable/_service.py
+++ b/acceptable/_service.py
@@ -59,8 +59,8 @@ class AcceptableService:
     This provides a nicer interface to manage the global API metadata within
     a single file.
 
-    It is just a proxy to the global metadata state, it does not store any
-    API state internally.
+    It is just a factory and proxy to the global metadata state, it does not
+    store any API state internally.
     """
 
     def __init__(self, name, group=None, metadata=METADATA):

--- a/acceptable/_service.py
+++ b/acceptable/_service.py
@@ -116,26 +116,8 @@ class AcceptableAPI:
         self.introduced_at = introduced_at
         self.options = options
         self.view_fn = None
-
-    @property
-    def request_schema(self):
-        return self._request_schema
-
-    @request_schema.setter
-    def request_schema(self, schema):
-        if schema is not None:
-            _validation.validate_schema(schema)
-        self._request_schema = schema
-
-    @property
-    def response_schema(self):
-        return self._response_schema
-
-    @response_schema.setter
-    def response_schema(self, schema):
-        if schema is not None:
-            _validation.validate_schema(schema)
-        self._response_schema = schema
+        self.request_schema = None
+        self.response_schema = None
 
     @property
     def methods(self):
@@ -158,8 +140,7 @@ class AcceptableAPI:
         self.view_fn = view_fn
 
         # support for legacy @validate_{body,output} decorators
+        # we don't know the order of decorators, so allow for both.
         view_fn._acceptable_metadata = self
-        # schema on the function have already been validated, so bypass the
-        # validation here
-        self._request_schema = getattr(view_fn, '_request_schema', None)
-        self._response_schema = getattr(view_fn, '_response_schema', None)
+        self.request_schema = getattr(view_fn, '_request_schema', None)
+        self.response_schema = getattr(view_fn, '_response_schema', None)

--- a/acceptable/_validation.py
+++ b/acceptable/_validation.py
@@ -64,7 +64,7 @@ def validate_body(schema):
     """
     def decorator(fn):
         validate_schema(schema)
-        fn.request_schema = schema
+        fn._request_schema = schema
         if hasattr(fn, '_acceptable_metadata'):
             fn._acceptable_metadata.request_schema = schema
 
@@ -94,7 +94,7 @@ def validate_body(schema):
 
 def preserve_function_attrs(fn, wrapper):
     wrapper._request_schema = getattr(fn, '_request_schema', None)
-    wrapper._response_schema = getattr(fn, '_reponse_schema', None)
+    wrapper._response_schema = getattr(fn, '_response_schema', None)
     if hasattr(fn, '_acceptable_metadata'):
         wrapper._acceptable_metadata = fn._acceptable_metadata
 

--- a/acceptable/tests/test_service.py
+++ b/acceptable/tests/test_service.py
@@ -13,6 +13,7 @@ from acceptable._service import (
     APIMetadata,
     AcceptableAPI,
     AcceptableService,
+    InvalidAPI,
 )
 from acceptable._validation import (
     validate_body,
@@ -29,7 +30,7 @@ class APIMetadataTestCase(TestCase):
         metadata.register_service('test', None)
         metadata.register_api('test', None, api1)
         self.assertRaises(
-            AssertionError,
+            InvalidAPI,
             metadata.register_api,
             'other', None, api2,
         )
@@ -42,7 +43,7 @@ class APIMetadataTestCase(TestCase):
         metadata.register_service('other', None)
         metadata.register_api('test', None, api1)
         self.assertRaises(
-            AssertionError,
+            InvalidAPI,
             metadata.register_api,
             'other', None, api2,
         )
@@ -88,7 +89,7 @@ class APIMetadataTestCase(TestCase):
 
         metadata.bind(app, 'test')
 
-        self.assertEquals(api1_impl, app.view_functions['api1'])
+        self.assertEqual(api1_impl, app.view_functions['api1'])
         self.assertNotIn('api2', app.view_functions)
 
         resp = app.test_client().get('/api1')
@@ -214,7 +215,7 @@ class AcceptableAPITestCase(TestCase):
         fixture = self.useFixture(ServiceFixture())
 
         self.assertRaises(
-            AssertionError,
+            InvalidAPI,
             fixture.service.api,
             '/bar',
             'foo_api',
@@ -223,7 +224,7 @@ class AcceptableAPITestCase(TestCase):
     def test_cannot_duplicate_url_and_method(self):
         fixture = self.useFixture(ServiceFixture())
         self.assertRaises(
-            AssertionError,
+            InvalidAPI,
             fixture.service.api,
             '/foo',
             'bar',

--- a/acceptable/tests/test_service.py
+++ b/acceptable/tests/test_service.py
@@ -10,8 +10,13 @@ from testtools.matchers import (
 )
 
 from acceptable._service import (
+    APIMetadata,
     AcceptableService,
 )
+
+
+class APIMetadataTestCase(TestCase):
+    pass
 
 
 class AcceptableServiceTestCase(TestCase):
@@ -28,9 +33,9 @@ class AcceptableServiceTestCase(TestCase):
         def view():
             return "test view", 200
 
-        service = AcceptableService('service')
+        service = AcceptableService('service', metadata=APIMetadata())
         api = service.api('/foo', 'foo_api')
-        api.register_view('1.0', view)
+        api.register_view(view, '1.0')
 
         app = Flask(__name__)
         service.bind(app)
@@ -45,18 +50,19 @@ class ServiceFixture(Fixture):
     """A reusable fixture that sets up several API endpoints."""
 
     def _setUp(self):
-        self.service = AcceptableService('service')
+        self.metadata = APIMetadata()
+        self.service = AcceptableService('service', metadata=self.metadata)
         foo_api = self.service.api('/foo', 'foo_api', methods=['POST'])
-        foo_api.register_view('1.0', self.foo)
+
+        @foo_api.view(introduced_at='1.0')
+        def foo():
+            return "foo", 200
 
     def bind(self, app=None):
         if app is None:
             app = Flask(__name__)
         self.service.bind(app)
         return app
-
-    def foo(self):
-        return "foo", 200
 
 
 class AcceptableAPITestCase(TestCase):

--- a/acceptable/tests/test_service.py
+++ b/acceptable/tests/test_service.py
@@ -259,7 +259,7 @@ class LegacyAcceptableAPITestCase(TestCase):
 
         self.assertEqual(
             schema,
-            fixture.service.apis['blah']._request_schema,
+            fixture.service.apis['blah'].request_schema,
         )
 
     def test_validate_body_records_metadata_reversed_order(self):
@@ -274,7 +274,7 @@ class LegacyAcceptableAPITestCase(TestCase):
 
         self.assertEqual(
             schema,
-            fixture.service.apis['blah']._request_schema,
+            fixture.service.apis['blah'].request_schema,
         )
 
     def test_validate_output_records_metadata(self):
@@ -289,7 +289,7 @@ class LegacyAcceptableAPITestCase(TestCase):
 
         self.assertEqual(
             schema,
-            fixture.service.apis['blah']._response_schema,
+            fixture.service.apis['blah'].response_schema,
         )
 
     def test_validate_output_records_metadata_reversed(self):
@@ -304,7 +304,7 @@ class LegacyAcceptableAPITestCase(TestCase):
 
         self.assertEqual(
             schema,
-            fixture.service.apis['blah']._response_schema,
+            fixture.service.apis['blah'].response_schema,
         )
 
     def test_validate_both_records_metadata(self):
@@ -321,14 +321,12 @@ class LegacyAcceptableAPITestCase(TestCase):
 
         self.assertEqual(
             schema1,
-            fixture.service.apis['blah']._request_schema,
+            fixture.service.apis['blah'].request_schema,
         )
         self.assertEqual(
             schema2,
-            fixture.service.apis['blah']._response_schema,
+            fixture.service.apis['blah'].response_schema,
         )
-
-
 
 
 class IsResponse(Matcher):

--- a/acceptable/tests/test_service.py
+++ b/acceptable/tests/test_service.py
@@ -68,6 +68,7 @@ class AcceptableAPITestCase(TestCase):
         self.assertEqual(api.url, '/new')
         self.assertEqual(api.options, {})
         self.assertEqual(api.name, 'blah')
+
         self.assertEqual(api, fixture.service.apis['blah'])
 
     def test_view_decorator_and_bind_works(self):
@@ -110,25 +111,6 @@ class AcceptableAPITestCase(TestCase):
             return "new view", 200
 
         self.assertEqual(new_api.introduced_at, 1)
-
-    def test_view_decorator_works(self):
-        fixture = self.useFixture(ServiceFixture())
-
-        new_api = fixture.service.api('/new', 'blah')
-        self.assertEqual(new_api.introduced_at, None)
-
-        @new_api.view(introduced_at='1.0')
-        def new_view():
-            return "new view", 200
-
-        app = fixture.bind()
-
-        client = app.test_client()
-        resp = client.get('/new')
-
-        self.assertThat(resp, IsResponse("new view"))
-        view = app.view_functions['blah']
-        self.assertEqual(view.__name__, 'new_view')
 
     def test_can_still_call_view_directly(self):
         fixture = self.useFixture(ServiceFixture())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask
+Flask<1.0
 jsonschema
 pyyaml
 jinja2


### PR DESCRIPTION
This adds a global datastructure for storing API metadata

This provides 2 benefits:

1) One place to read the services metadata from, rather than having to locate all the service instances.
2) We can enforce uniqueness constraints at import time, rather than when adding to a flask app. This is useful if we want to have metadata that is not bound to an app.

It also adds the concept of api groups, the default group being None. Most of our services that use acceptable have a single AcceptableService instance. But some larger ones have multple AcceptableService instances, which effectively group apis, and bind each one explicitly to the flask app.

To support this idea, while still being able to enforce uniqueness across and document a whole api, we add a group parameter to AcceptableService. Combined with the change of 'vendor' to 'name', would mean something like this:

    service = AcceptableService('vendor')

to 

    service = AcceptableService('my_service', group='foo')


    

 