### PR TITLE
Support groups in api metadata and rendering groups in html docs

### DIFF
--- a/acceptable/tests/test_main.py
+++ b/acceptable/tests/test_main.py
@@ -299,7 +299,10 @@ class RenderMarkdownTests(testtools.TestCase):
         )
 
         top_level_md = yaml.safe_load(output['metadata.yaml'])
-        self.assertEqual({'site_title': 'SERVICE Documentation'}, top_level_md)
+        self.assertEqual(
+            {'site_title': 'SERVICE Documentation: version 1'},
+            top_level_md,
+        )
 
         md = yaml.safe_load(output['en/metadata.yaml'])
         self.assertEqual({


### PR DESCRIPTION
Store the group and service info the json metadata, and use it to generate grouped navigation in the html docs