### PR TITLE
Support having undocumented apis

### DIFF
--- a/acceptable/__main__.py
+++ b/acceptable/__main__.py
@@ -177,6 +177,8 @@ def parse(metadata):
                 'doc': api.docs,
                 'changelog': api._changelog,
             }
+            if api.undocumented:
+                api_metadata[name]['undocumented'] = True
 
             locations[name] = {
                 'api': api.location,
@@ -212,6 +214,8 @@ def render_markdown(metadata, name):
     version = metadata.pop('$version', None)
 
     for api_name, api in metadata.items():
+        if api.get('undocumented', False):
+            continue
         page_file = '{}.md'.format(api_name)
         page = {'title': api_name, 'location': page_file}
         api_groups[api.get('api_group')].append(page)
@@ -229,10 +233,12 @@ def render_markdown(metadata, name):
                 sorted(default_group, key=sort_key),
             )
         for group in sorted(api_groups):
-            navigation.append({
-                'title': group,
-                'children': list(sorted(api_groups[group], key=sort_key)),
-            })
+            children = list(sorted(api_groups[group], key=sort_key))
+            if children:
+                navigation.append({
+                    'title': group,
+                    'children': children,
+                })
 
     yield en / 'index.md', index_tmpl.render(service_name=name)
 

--- a/acceptable/_service.py
+++ b/acceptable/_service.py
@@ -143,7 +143,14 @@ class AcceptableService:
 class AcceptableAPI:
     """Metadata abount an api endpoint."""
 
-    def __init__(self, name, url, introduced_at, options={}, location=None):
+    def __init__(
+            self,
+            name,
+            url,
+            introduced_at,
+            options={},
+            location=None,
+            undocumented=False):
         self.name = name
         self.url = url
         self.introduced_at = introduced_at
@@ -160,6 +167,7 @@ class AcceptableAPI:
             self.location = get_callsite_location()
         else:
             self.location = location
+        self.undocumented = undocumented
 
     @property
     def methods(self):


### PR DESCRIPTION
This adds undocumented api support, which means we can still use acceptable for an api, but not have it appear in documentation