### PR TITLE
add a deprecated_at flag to apis, which moves deprecated apis to bottom

### DIFF
--- a/acceptable/_service.py
+++ b/acceptable/_service.py
@@ -139,6 +139,7 @@ class AcceptableService():
             name,
             introduced_at=None,
             undocumented=False,
+            deprecated_at=None,
             **options):
         """Add an API to the service.
 
@@ -159,12 +160,19 @@ class AcceptableService():
             introduced_at,
             options,
             undocumented=undocumented,
+            deprecated_at=deprecated_at,
             location=location,
         )
         self.metadata.register_api(self.name, self.group, api)
         return api
 
-    def django_api(self, name, introduced_at, undocumented=False, **options):
+    def django_api(
+            self,
+            name,
+            introduced_at,
+            undocumented=False,
+            deprecated_at=None,
+            **options):
         """Add an django API handler to the service.
 
         :param name: This is the name of the django url to use.
@@ -182,6 +190,7 @@ class AcceptableService():
             options,
             location=location,
             undocumented=undocumented,
+            deprecated_at=deprecated_at,
         )
         self.metadata.register_api(self.name, self.group, api)
         return api
@@ -205,7 +214,8 @@ class AcceptableAPI():
             introduced_at,
             options={},
             location=None,
-            undocumented=False):
+            undocumented=False,
+            deprecated_at=None):
         self.service = service
         self.name = name
         self.url = url
@@ -225,6 +235,7 @@ class AcceptableAPI():
         else:
             self.location = location
         self.undocumented = undocumented
+        self.deprecated_at = deprecated_at
 
     def _set_docs_from_docstring(self, docstring):
         """Dedent docstring, special casing the first line."""

--- a/acceptable/_service.py
+++ b/acceptable/_service.py
@@ -173,7 +173,7 @@ class AcceptableService():
             undocumented=False,
             deprecated_at=None,
             **options):
-        """Add an django API handler to the service.
+        """Add a django API handler to the service.
 
         :param name: This is the name of the django url to use.
 

--- a/acceptable/djangoutil.py
+++ b/acceptable/djangoutil.py
@@ -155,7 +155,8 @@ class DjangoAPI(AcceptableAPI):
             introduced_at,
             options={},
             location=None,
-            undocumented=False):
+            undocumented=False,
+            deprecated_at=None):
         # leave url blank, as we can't know it until django has set itself up
         # properly
         super().__init__(
@@ -166,6 +167,7 @@ class DjangoAPI(AcceptableAPI):
             options,
             location,
             undocumented,
+            deprecated_at,
         )
 
         self._form = None

--- a/acceptable/templates/api_page.md.j2
+++ b/acceptable/templates/api_page.md.j2
@@ -5,7 +5,8 @@ table_of_contents: false
 # {{name}} {{ '**(DEPRECATED)**' if deprecated_at else '' }}
 
 {% if deprecated_at %}
-*Deprecated in version {{deprecated_at}}*
+!!! Warning "Deprecated"
+    Deprecated from version {{deprecated_at}}
 {% endif %}
 {% if deprecated_at != introduced_at %}
 *Introduced in version {{introduced_at}}*

--- a/acceptable/templates/api_page.md.j2
+++ b/acceptable/templates/api_page.md.j2
@@ -1,9 +1,15 @@
 ---
-title: {{name}}
+title: {{name}}{{ ' DEPRECATED' if deprecated_at else '' }}
+table_of_contents: false
 ---
-# {{name}}
+# {{name}} {{ '**(DEPRECATED)**' if deprecated_at else '' }}
 
+{% if deprecated_at %}
+*Deprecated in version {{deprecated_at}}*
+{% endif %}
+{% if deprecated_at != introduced_at %}
 *Introduced in version {{introduced_at}}*
+{% endif %}
 
 Summary: **{{methods|join('|')}} {{url}}**
 

--- a/acceptable/templates/index.md.j2
+++ b/acceptable/templates/index.md.j2
@@ -4,7 +4,6 @@ title: {{service_name}} Documentation
 
 This is the documentation for version {{ version }} of {{service_name}}.
 
-
 {% if changelog %}
 ## Changelog
 

--- a/acceptable/tests/test_main.py
+++ b/acceptable/tests/test_main.py
@@ -332,6 +332,38 @@ class RenderMarkdownTests(testtools.TestCase):
             md
         )
 
+    def test_render_markdown_deprecated_at(self):
+        args = main.parse_args(
+            ['render', 'examples/api.json', '--name=SERVICE'])
+        m = self.metadata()
+        m['api2']['deprecated_at'] = 2
+        iterator = main.render_markdown(m, args)
+        output = OrderedDict((str(k), v) for k, v in iterator)
+
+        self.assertEqual(set([
+                'en/api1.md',
+                'en/api2.md',
+                'en/index.md',
+                'en/metadata.yaml',
+                'metadata.yaml',
+            ]),
+            set(output),
+        )
+
+        md = yaml.safe_load(output['en/metadata.yaml'])
+        self.assertEqual({
+                'navigation': [
+                    {'location': 'index.md', 'title': 'Index'},
+                    {'location': 'api1.md',  'title': 'api1'},
+                    {
+                        'title': 'Deprecated APIs',
+                        'children': [{'title': 'api2', 'location': 'api2.md'}],
+                    },
+                ],
+            },
+            md
+        )
+
     def test_render_markdown_multiple_groups(self):
         args = main.parse_args(
             ['render', 'examples/api.json', '--name=SERVICE'])


### PR DESCRIPTION
and marks them as deprecated