### PR TITLE
Sorted metadata

### DIFF
--- a/acceptable/__main__.py
+++ b/acceptable/__main__.py
@@ -35,7 +35,7 @@ if PY2:
 
 
 def tojson_filter(json_object, indent=4):
-    return json.dumps(json_object, indent=indent, sort_keys=True)
+    return json.dumps(json_object, indent=indent)
 
 
 TEMPLATES = Environment(
@@ -177,7 +177,7 @@ def parse_args(raw_args=None, parser_cls=None, stdin=None):
 def metadata_cmd(cli_args):
     import_metadata(cli_args.modules)
     current, _ = get_metadata().serialize()
-    print(json.dumps(current, indent=2, sort_keys=True))
+    print(json.dumps(current, indent=2))
 
 
 def import_metadata(module_paths):
@@ -314,7 +314,7 @@ def lint_cmd(cli_args, stream=sys.stdout):
     if cli_args.update:
         if not has_errors or cli_args.force:
             with open(cli_args.metadata.name, 'w') as f:
-                json.dump(current, f, indent=2, sort_keys=True)
+                json.dump(current, f, indent=2)
 
     return 1 if has_errors else 0
 

--- a/acceptable/_validation.py
+++ b/acceptable/_validation.py
@@ -11,7 +11,7 @@ import functools
 
 import jsonschema
 
-from acceptable.util import get_callsite_location
+from acceptable.util import get_callsite_location, sort_schema
 
 
 class DataValidationError(Exception):
@@ -74,7 +74,8 @@ def validate_body(schema):
     def decorator(fn):
         validate_schema(schema)
         wrapper = wrap_request(fn, schema)
-        record_schemas(fn, wrapper, location, request_schema=schema)
+        record_schemas(
+            fn, wrapper, location, request_schema=sort_schema(schema))
         return wrapper
 
     return decorator
@@ -159,7 +160,8 @@ def validate_output(schema):
     def decorator(fn):
         validate_schema(schema)
         wrapper = wrap_response(fn, schema)
-        record_schemas(fn, wrapper, location, response_schema=schema)
+        record_schemas(
+            fn, wrapper, location, response_schema=sort_schema(schema))
         return wrapper
 
     return decorator

--- a/acceptable/djangoutil.py
+++ b/acceptable/djangoutil.py
@@ -14,7 +14,7 @@ import django
 from django.forms import widgets, fields
 
 from acceptable._service import AcceptableAPI
-from acceptable.util import clean_docstring
+from acceptable.util import clean_docstring, sort_schema
 
 logger = logging.getLogger('acceptable')
 _urlmap = None
@@ -210,7 +210,7 @@ class DjangoAPI(AcceptableAPI):
     def django_form(self, form):
         self._form = form
         schema = get_form_schema(form)
-        self.request_schema = schema
+        self.request_schema = sort_schema(schema)
 
     def handler(self, handler_class):
         """Link to an API handler class (e.g. piston or DRF)."""

--- a/acceptable/management/commands/acceptable.py
+++ b/acceptable/management/commands/acceptable.py
@@ -61,7 +61,7 @@ class Command(BaseCommand):
         func(options, current)
 
     def metadata(self, options, current):
-        print(json.dumps(current, indent=2, sort_keys=True))
+        print(json.dumps(current, indent=2))
 
     def version(self, options, current, stream=sys.stdout):
         file_metadata = load_metadata(options['metadata'])

--- a/acceptable/tests/test_service.py
+++ b/acceptable/tests/test_service.py
@@ -113,6 +113,22 @@ class APIMetadataTestCase(TestCase):
         self.assertThat(resp, IsResponse('api1'))
 
 
+    def serialize_preserves_declaration_order(self):
+        metadata = APIMetadata()
+        svc = metadata.register_service('test', 'group')
+        svc.api('api5', '/api/5', 1)
+        svc.api('api1', '/api/1', 1)
+        svc.api('api3', '/api/3', 1)
+        svc.api('api2', '/api/2', 1)
+
+        serialized = metadata.serialize()
+
+        self.assertEqual(
+            ['api5', 'api1', 'api3', 'api2'],
+            list(serialized['group']['apis'])
+        )
+
+
 class AcceptableServiceTestCase(TestCase):
 
     def test_can_register_url_route(self):
@@ -188,6 +204,28 @@ class AcceptableAPITestCase(TestCase):
         api.response_schema = schema
         self.assertEqual(api.request_schema, schema)
         self.assertEqual(api.response_schema, schema)
+
+    def test_acceptable_api_schemas_are_sorted(self):
+        fixture = self.useFixture(ServiceFixture())
+        api = fixture.service.api('/api', 'blah')
+        schema = {
+            'type': 'object',
+            'properties': {
+                '5': {'type': 'string'},
+                '1': {'type': 'string'},
+                '3': {'type': 'string'},
+            }
+        }
+        api.request_schema = schema
+        api.response_schema = schema
+        self.assertEqual(
+            ['1', '3', '5'],
+            list(api.request_schema['properties']),
+        )
+        self.assertEqual(
+            ['1', '3', '5'],
+            list(api.response_schema['properties']),
+        )
 
     def test_acceptable_api_changelog_is_recorded(self):
         fixture = self.useFixture(ServiceFixture())

--- a/acceptable/tests/test_util.py
+++ b/acceptable/tests/test_util.py
@@ -1,0 +1,37 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+# Copyright 2017 Canonical Ltd.  This software is licensed under the
+# GNU Lesser General Public License version 3 (see the file LICENSE).
+import testtools
+
+from acceptable import util
+
+
+class UtilsTestCase(testtools.TestCase):
+
+    def test_sort_schema_simple(self):
+        srtd = util.sort_schema({
+            '5': '5',
+            '1': '1',
+            '3': '3',
+        })
+        self.assertEqual(['1','3','5'], list(srtd))
+
+    def test_sort_schema_simple(self):
+        d = {'5': '5', '1': '1', '3': '3'}
+        l = [5, 1, 3]
+        srtd = util.sort_schema({
+            'foo': {
+                'b': [d],
+                'a': [l]
+            }
+        })
+
+        # check we sort nested dicts
+        self.assertEqual(['a','b'], list(srtd['foo']))
+        # check we sort dicts nested in lists
+        self.assertEqual(['1','3','5'], list(srtd['foo']['b'][0]))
+        # ensure we preserve the order of lists
+        self.assertEqual([5, 1, 3], list(srtd['foo']['a'][0]))

--- a/acceptable/util.py
+++ b/acceptable/util.py
@@ -4,7 +4,10 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import *  # NOQA
 
+from collections import OrderedDict
+import difflib
 import inspect
+import pprint
 import sys
 import textwrap
 
@@ -33,3 +36,35 @@ def clean_docstring(docstring):
     return docstring
 
 
+def _sort_schema(schema):
+    """Recursively sorts a JSON schema by dict key."""
+
+    if isinstance(schema, dict):
+        for k, v in sorted(schema.items()):
+            if isinstance(v, dict):
+                yield k, OrderedDict(_sort_schema(v))
+            elif isinstance(v, list):
+                yield k, list(_sort_schema(v))
+            else:
+                yield k, v
+    elif isinstance(schema, list):
+        for v in schema:
+            if isinstance(v, dict):
+                yield OrderedDict(_sort_schema(v))
+            elif isinstance(v, list):
+                yield list(_sort_schema(v))
+            else:
+                yield v
+    else:
+        yield d
+
+
+def sort_schema(schema):
+    sorted_schema = OrderedDict(_sort_schema(schema))
+    # ensure sorting the schema does not alter it
+    if schema != sorted_schema:
+        d1 = pprint.pformat(schema).splitlines()
+        d2 = pprint.pformat(sorted_schema).splitlines()
+        diff = '\n'.join(difflib.ndiff(d1, d2))
+        raise RuntimeError('acceptable: sorting schema failed:\n' + diff)
+    return sorted_schema


### PR DESCRIPTION
Metadata is now sort-stable, in order of import. This allows developers to control the order of apis in docs by moving them around in the file. 

To maintain stable json output, this meant sorting JSON schema at import time, since we define them as dict literals, currently.