### PR TITLE
Fix response tuples in Flask 1.x

### DIFF
--- a/acceptable/_validation.py
+++ b/acceptable/_validation.py
@@ -173,14 +173,8 @@ def wrap_response(fn, schema):
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
         result = fn(*args, **kwargs)
-        resp = code = headers = None
         if isinstance(result, tuple):
-            if len(result) == 1:
-                resp = result[0]
-            elif len(result) == 2:
-                resp, code = result
-            elif len(result) == 3:
-                resp, code, headers = result
+            resp = result[0]
         else:
             resp = result
         if not isinstance(resp, (list, dict)):
@@ -195,12 +189,10 @@ def wrap_response(fn, schema):
                 "Response does not comply with output schema: %r.\n%s"\
                 % (error_list, resp)
 
-        return_value = [jsonify(resp)]
-        if code is not None:
-            return_value.append(code)
-        if headers is not None:
-            return_value.append(headers)
-        return tuple(return_value)
+        if isinstance(result, tuple):
+            return (jsonify(resp), *result[1:])
+        else:
+            return jsonify(result)
     return wrapper
 
 

--- a/acceptable/_validation.py
+++ b/acceptable/_validation.py
@@ -190,7 +190,7 @@ def wrap_response(fn, schema):
                 % (error_list, resp)
 
         if isinstance(result, tuple):
-            return (jsonify(resp), *result[1:])
+            return (jsonify(resp), ) + result[1:]
         else:
             return jsonify(result)
     return wrapper

--- a/acceptable/tests/test_validation.py
+++ b/acceptable/tests/test_validation.py
@@ -236,20 +236,6 @@ class ValidateOutputTests(TestCase):
         self.assertEqual(200, resp.status_code)
         self.assertResponseJsonEqual(resp, returned_payload)
 
-    def test_passes_on_good_payload_single_tuple_return_parameter(self):
-        returned_payload = ({'foo': 'bar'}, )
-
-        def view():
-            return returned_payload
-
-        app = self.useFixture(FlaskValidateBodyFixture(
-            output_schema={'type': 'object'},
-            view_fn=view
-        ))
-        resp = app.post_json({})
-        self.assertEqual(200, resp.status_code)
-        self.assertResponseJsonEqual(resp, returned_payload[0])
-
     def test_passes_on_good_payload_double_return_parameter(self):
         returned_payload = {'foo': 'bar'}
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     ],
     extras_require=dict(
         flask=[
-            'Flask<1.0',
+            'Flask<2.0',
         ],
         django=[
             'django>=1.11,<2.1',


### PR DESCRIPTION
The `validate_output` wrapper currently turns single object results into single-element tuples, whereas Flask's `make_response` expects a response object, a string, or [a tuple in the form (response, status, headers) or (response, headers)](https://flask.palletsprojects.com/en/0.12.x/api/#flask.Flask.make_response). This works in Flask 0.12 due to details in the internal implementation, but it breaks [Flask 1.0, where `make_response` was refactored and response parsing made stricter](https://github.com/pallets/flask/pull/2256/files):

```
TypeError: The view function did not return a valid response tuple.
    The tuple must have the form (body, status, headers), (body, status), or (body, headers).
```

This branch simplifies the wrapper's logic to just perform the validation on the response body and return a single object or a tuple with the same length as its input. Unfortunately it'll break callers who expect the (wrong) response transformation. E.g. in our case, I found a few `response, = some_decorated_view()` that need to drop that trailing comma as the view function just returns a plain dict (which is easy to detect and fix, fortunately). Granted we could just unpack single-element responses and return the bare contents, but that's still unexpected behaviour imho.

Is this why the flask dep is `Flask<1.0`? Tests now pass with Flask 1.1.1.