### PR TITLE
Fix Py3 Attr should raise AttributeError not NameError

### DIFF
--- a/acceptable/mocks.py
+++ b/acceptable/mocks.py
@@ -43,7 +43,7 @@ class Attrs(object):
         try:
             return self.__attrs[name]
         except KeyError:
-            raise NameError(name)
+            raise AttributeError(name)
 
     def __iter__(self):
         return iter(self.__attrs.items())


### PR DESCRIPTION
This was causing converting an Attr to dict to fail.