### PR TITLE
Fix issue 104, support Django >= 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,10 @@ cache: pip
 dist: trusty
 sudo: False
 python:
-    - 2.7
     - 3.5
     - 3.6
 install: 
-    - pip install tox-travis "six>=1.14.0"
+    - pip install tox-travis
 script: tox
 after_success:
   - coveralls

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test: env/.done
 	env/bin/python setup.py test
 
 env/bin/tox: env/.done
-	env/bin/pip install tox "six>=1.14.0"
+	env/bin/pip install tox
 
 .PHONY: tox
 tox: env/bin/tox

--- a/acceptable/management/commands/acceptable.py
+++ b/acceptable/management/commands/acceptable.py
@@ -25,22 +25,15 @@ class Command(BaseCommand):
     help = 'Generate Acceptable API Metadata from project'
 
     def add_arguments(self, parser):
-        cmd = self
+        # Handle our subparsers in a way that is suppoert in Django 2.1+
+        subparsers = parser.add_subparsers(dest='cmd')
 
-        class SubParser(CommandParser):
-            """Django command aware subparser."""
-            def __init__(self, **kwargs):
-                super().__init__(cmd, **kwargs)
-
-        subparser = parser.add_subparsers(dest='cmd', parser_class=SubParser)
-        subparser.required = True
-
-        metadata_parser = subparser.add_parser(
+        metadata_parser = subparsers.add_parser(
             'metadata',
             help='Import project and print extracted metadata in json')
         metadata_parser.set_defaults(func=self.metadata)
 
-        version_parser = subparser.add_parser(
+        version_parser = subparsers.add_parser(
             'api-version',
             help='Get the current api version from json meta, and '
                  'optionally from current code also',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 
-VERSION = '0.29'
+VERSION = '0.30'
 
 
 setup(
@@ -31,7 +31,7 @@ setup(
             'Flask<2.0',
         ],
         django=[
-            'django>=1.11,<2.1',
+            'django>=2.1',
         ]
     ),
     test_suite='acceptable.tests',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36,py37,py38
+envlist = py35,py36
 skip_missing_interpreters = True
 skipsdist = True
 
@@ -9,7 +9,9 @@ deps = -r{toxinidir}/requirements-dev.txt
 extras =
     flask
     django
-commands = coverage run --source acceptable --omit "acceptable/tests/*" setup.py test
+commands =
+    pip uninstall -y argparse 
+    coverage run --source acceptable --omit "acceptable/tests/*" setup.py test
 passenv =
     TRAVIS
     TRAVIS_BRANCH

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36
+envlist = py27,py35,py36,py37,py38
 skip_missing_interpreters = True
 skipsdist = True
 


### PR DESCRIPTION
With these changes, support for Django >= 2.1 is added. (And support for
older versions is dropped)
Version number has been bumped to prepare for a new release.