### PR TITLE
Fix failing `make test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ env/.done: requirements-dev.txt setup.py
 	virtualenv -p python3 env
 	env/bin/pip install -e .[flask,django]
 	env/bin/pip install -r requirements-dev.txt
+	env/bin/pip uninstall -y argparse  # we want to use the built-in version of argparse
 	touch $@
 
 .PHONY: text


### PR DESCRIPTION
An older version of argparse is being installed by one of the deps (testtools -> unittest2) which results in failing tests. We want to use the the built-in argparse instead.

Note that tox.ini was already uninstalling the old argparse, so tox test runs were passing.