### PR TITLE
Remove old python2 compatibility elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ build/
 docs/
 .tox
 .coverage
+venv/
+.eggs/

--- a/acceptable/__init__.py
+++ b/acceptable/__init__.py
@@ -2,13 +2,6 @@
 # GNU Lesser General Public License version 3 (see the file LICENSE).
 
 
-# including this causes issues with type types in __all__, which need to be
-# native strings, so we explicitly do not want unicode literals here
-# from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-
 from ._service import (  # NOQA
     AcceptableService,
     get_metadata,

--- a/acceptable/__main__.py
+++ b/acceptable/__main__.py
@@ -1,14 +1,5 @@
 # Copyright 2017 Canonical Ltd.  This software is licensed under the
 # GNU Lesser General Public License version 3 (see the file LICENSE).
-from __future__ import print_function
-from __future__ import division
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from builtins import *  # NOQA
-__metaclass__ = type
-
-from future.utils import PY2, raise_from
-
 import argparse
 from collections import defaultdict, OrderedDict
 from importlib import import_module
@@ -26,13 +17,6 @@ import yaml
 
 from acceptable import get_metadata, lint
 from acceptable.dummy_importer import DummyImporterContext
-
-if PY2:
-    from future.types.newlist import newlist
-    from future.types.newdict import newdict
-    from yaml.representer import SafeRepresenter
-    SafeRepresenter.add_representer(newlist, SafeRepresenter.represent_list)
-    SafeRepresenter.add_representer(newdict, SafeRepresenter.represent_dict)
 
 
 def tojson_filter(json_object, indent=4):
@@ -271,10 +255,10 @@ def load_metadata(stream):
     """Load JSON metadata from opened stream."""
     try:
         metadata = json.load(
-            stream, encoding='utf8', object_pairs_hook=OrderedDict)
+            stream, object_pairs_hook=OrderedDict)
     except json.JSONDecodeError as e:
         err = RuntimeError('Error parsing {}: {}'.format(stream.name, e))
-        raise_from(err, e)
+        raise err from e
     else:
         # convert changelog keys back to ints for sorting
         for group in metadata:
@@ -406,7 +390,7 @@ def lint_cmd(cli_args, stream=sys.stdout):
 
 
 def doubles_cmd(cli_args, stream=sys.stdout):
-    metadata = json.load(cli_args.metadata, encoding='utf8',  
+    metadata = json.load(cli_args.metadata,
         object_pairs_hook=OrderedDict)
     if cli_args.new_style:
         from . import generate_mocks

--- a/acceptable/_build_doubles.py
+++ b/acceptable/_build_doubles.py
@@ -18,12 +18,6 @@ modes of operation:
 In both cases, the service doubles are built by doing an AST parse of the
 python source file in question and extracting calls to acceptable functions.
 """
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
-from builtins import *  # NOQA
-
 import argparse
 import ast
 import collections

--- a/acceptable/_doubles.py
+++ b/acceptable/_doubles.py
@@ -6,16 +6,10 @@
 The ServiceMock class in this file is used at test-run-time to mock out a call
 to a remote service API view.
 """
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import *  # NOQA
-
 import functools
 import json
+from urllib.parse import urljoin
 
-from future.moves.urllib.parse import urljoin
 from fixtures import Fixture
 import responses
 

--- a/acceptable/_service.py
+++ b/acceptable/_service.py
@@ -2,13 +2,6 @@
 # GNU Lesser General Public License version 3 (see the file LICENSE).
 
 """acceptable - Programatic API Metadata for Flask apps."""
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import *  # NOQA
-__metaclass__ = type
-
 from collections import OrderedDict, defaultdict
 import textwrap
 

--- a/acceptable/_validation.py
+++ b/acceptable/_validation.py
@@ -1,11 +1,5 @@
 # Copyright 2017-2020 Canonical Ltd.  This software is licensed under the
 # GNU Lesser General Public License version 3 (see the file LICENSE).
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import *  # NOQA
-
 import json
 import functools
 

--- a/acceptable/djangoutil.py
+++ b/acceptable/djangoutil.py
@@ -1,13 +1,5 @@
 # Copyright 2017 Canonical Ltd.  This software is licensed under the
 # GNU Lesser General Public License version 3 (see the file LICENSE).
-
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import *  # NOQA
-__metaclass__ = type
-
 import logging
 
 import django

--- a/acceptable/dummy_importer.py
+++ b/acceptable/dummy_importer.py
@@ -1,15 +1,7 @@
 # Copyright 2019 Canonical Ltd.  This software is licensed under the
 # GNU Lesser General Public License version 3 (see the file LICENSE).
-from __future__ import print_function
-from future import standard_library
-
-standard_library.install_aliases()
 import sys
-try:
-    # install_aliases() doesn't seem to include unittest.mock
-    from mock import MagicMock
-except ImportError:
-    from unittest.mock import MagicMock
+from unittest.mock import MagicMock
 
 
 class DummyFinder(object):

--- a/acceptable/generate_doubles.py
+++ b/acceptable/generate_doubles.py
@@ -1,6 +1,5 @@
 # Copyright 2019 Canonical Ltd.  This software is licensed under the
 # GNU Lesser General Public License version 3 (see the file LICENSE).
-from __future__ import print_function
 import json
 import textwrap
 from sys import stdout

--- a/acceptable/generate_mocks.py
+++ b/acceptable/generate_mocks.py
@@ -1,6 +1,5 @@
 # Copyright 2019 Canonical Ltd.  This software is licensed under the
 # GNU Lesser General Public License version 3 (see the file LICENSE).
-from __future__ import print_function
 from collections import defaultdict
 import json
 import textwrap

--- a/acceptable/lint.py
+++ b/acceptable/lint.py
@@ -1,12 +1,5 @@
 # Copyright 2017 Canonical Ltd.  This software is licensed under the
 # GNU Lesser General Public License version 3 (see the file LICENSE).
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import *  # NOQA
-__metaclass__ = type
-
 from enum import IntEnum
 import os
 

--- a/acceptable/management/commands/acceptable.py
+++ b/acceptable/management/commands/acceptable.py
@@ -1,14 +1,7 @@
 
 # Copyright 2017 Canonical Ltd.  This software is licensed under the
 # GNU Lesser General Public License version 3 (see the file LICENSE).
-
 """acceptable - Programatic API Metadata for Flask apps."""
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import *  # NOQA
-__metaclass__ = type
 
 import argparse
 import json

--- a/acceptable/mocks.py
+++ b/acceptable/mocks.py
@@ -1,10 +1,5 @@
 # Copyright 2019 Canonical Ltd.  This software is licensed under the
 # GNU Lesser General Public License version 3 (see the file LICENSE).
-from __future__ import absolute_import
-from future import standard_library
-
-standard_library.install_aliases()
-
 from collections import namedtuple
 import copy
 from json import dumps as json_dumps
@@ -22,9 +17,9 @@ class Attrs(object):
     """A utility class allowing the creation of namespaces from a dict.
     Also provides an iterator over the items of the original dict.
 
-    This is used by both Service and ServiceMock to create their 
+    This is used by both Service and ServiceMock to create their
     endpoints attributes.
-    
+
     e.g:
     a = Attrs(dict(b=1, c=2))
     assert a.b == 1
@@ -32,13 +27,13 @@ class Attrs(object):
     assert dir(a) == ['b', 'c']
     """
     def __init__(self, attrs):
-        # I think python name mangling is ok here to help avoid collisions 
+        # I think python name mangling is ok here to help avoid collisions
         # between instance attributes and names in attrs
         self.__attrs = dict(attrs)
-    
+
     def __dir__(self):
         return list(self.__attrs)
-    
+
     def __getattr__(self, name):
         try:
             return self.__attrs[name]
@@ -288,7 +283,7 @@ class Endpoint(object):
         self._request_schema = endpoint_spec.request_schema
         self._response_schema = endpoint_spec.response_schema
         self._response_callback = response_callback
-    
+
     @property
     def service_name(self):
         return self._service_name
@@ -323,7 +318,7 @@ class Endpoint(object):
 
     def set_response_callback(self, callback):
         self._response_callback = callback
-        
+
     def set_response(self, status=200, headers=None, body=None, json=None):
         self._response_callback = response_callback_factory(status, headers, body, json)
 
@@ -347,8 +342,8 @@ class Endpoint(object):
 
 
 class ServiceMock(object):
-    """Provides access to the endpoint mocks for this service and some functions 
-    to get calls made to the services endpoints. 
+    """Provides access to the endpoint mocks for this service and some functions
+    to get calls made to the services endpoints.
      """
     def __init__(self, call_recorder, endpoints):
         self._call_recorder = call_recorder
@@ -399,7 +394,7 @@ class Service(object):
     Callable to create a context manager which will mock all the endpoints on
     the service.
 
-    Endpoints can also be individually called to return a context manager 
+    Endpoints can also be individually called to return a context manager
     which just mocks that endpoint.
     """
     def __init__(self, base_url, name, endpoint_specs):
@@ -427,7 +422,7 @@ class Service(object):
 class ServiceFactory(object):
     """Callable to create Service instances.
 
-    You can create multiple instances of a Service and configure each 
+    You can create multiple instances of a Service and configure each
     independently.
     """
     def __init__(self, name, endpoint_specs):

--- a/acceptable/responses.py
+++ b/acceptable/responses.py
@@ -1,20 +1,18 @@
 # Copyright 2019 Canonical Ltd.  This software is licensed under the
 # GNU Lesser General Public License version 3 (see the file LICENSE).
-from __future__ import absolute_import
-
 import responses
 
 
 class ResponsesManager(object):
     """The responses library is used to add mock behaviour into the requests
-    library. 
-    
-    It does this using the RequestsMock class, however only one of 
+    library.
+
+    It does this using the RequestsMock class, however only one of
     these can be active at a time. Attempting to start a new RequestsMock
     will remove any others hooked into requests.
-    
-    We use an instance of this class to manage use of the RequestsMock 
-    instance `responses.mock`. This allows us to start, stop and reset 
+
+    We use an instance of this class to manage use of the RequestsMock
+    instance `responses.mock`. This allows us to start, stop and reset
     the it at the right time.
     """
     def __init__(self):

--- a/acceptable/tests/_fixtures.py
+++ b/acceptable/tests/_fixtures.py
@@ -1,12 +1,5 @@
 # Copyright 2017 Canonical Ltd.  This software is licensed under the
 # GNU Lesser General Public License version 3 (see the file LICENSE).
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import *  # NOQA
-from future.utils import text_to_native_str
-
 import os
 import sys
 import textwrap
@@ -17,7 +10,7 @@ from acceptable import _service
 
 
 def clean_up_module(name, old_syspath=None):
-    sys.modules.pop(text_to_native_str(name))
+    sys.modules.pop(name)
     _service.clear_metadata()
 
     if old_syspath is not None:

--- a/acceptable/tests/test_build_doubles.py
+++ b/acceptable/tests/test_build_doubles.py
@@ -1,12 +1,5 @@
 # Copyright 2017-2018 Canonical Ltd.  This software is licensed under the
 # GNU Lesser General Public License version 3 (see the file LICENSE).
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import *  # NOQA
-from future.utils import PY2
-
 import ast
 import argparse
 import os.path
@@ -27,8 +20,6 @@ class BuildDoubleTestCase(TestCase):
 
     def setUp(self):
         super().setUp()
-        if PY2:
-            self.skipTest('py3 only')
 
 
 class ExtractSchemasFromSourceTests(BuildDoubleTestCase):

--- a/acceptable/tests/test_djangoutils.py
+++ b/acceptable/tests/test_djangoutils.py
@@ -1,11 +1,5 @@
 # Copyright 2017 Canonical Ltd.  This software is licensed under the
 # GNU Lesser General Public License version 3 (see the file LICENSE).
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import *  # NOQA
-
 import json
 import subprocess
 import sys

--- a/acceptable/tests/test_doubles.py
+++ b/acceptable/tests/test_doubles.py
@@ -1,12 +1,5 @@
 # Copyright 2017 Canonical Ltd.  This software is licensed under the
 # GNU Lesser General Public License version 3 (see the file LICENSE).
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import *  # NOQA
-from future.utils import PY2
-
 import json
 
 import requests
@@ -24,8 +17,6 @@ from acceptable._doubles import (
 class ServiceMockTests(TestCase):
 
     def setUp(self):
-        if PY2:
-            self.skipTest('py3 only')
         super().setUp()
         # service locations are cached between tests. This should eventually
         # be fixed, but until then it's easier to set them to an empty dict at

--- a/acceptable/tests/test_dummy_importer.py
+++ b/acceptable/tests/test_dummy_importer.py
@@ -1,9 +1,5 @@
 # Copyright 2019 Canonical Ltd.  This software is licensed under the
 # GNU Lesser General Public License version 3 (see the file LICENSE).
-from __future__ import print_function, absolute_import
-from future import standard_library
-standard_library.install_aliases()
-
 from acceptable.dummy_importer import DummyImporterContext
 import testtools
 from testtools.matchers import Not, Contains, Equals, Is
@@ -15,17 +11,17 @@ class DummyImporterContextTests(testtools.TestCase):
     def test_mock_fake_import(self):
         with DummyImporterContext():
             import zzzxxxvvv
-    
+
     def test_allowed_real_modules(self):
         class FakeModuleLoader(object):
             def __init__(self):
                 self.imported = False
                 self.module = object()
-            
+
             def find_module(self, fullname, path=None):
                 if fullname == 'zzzxxxvvv.test':
                     return self
-            
+
             def load_module(self, fullname):
                 self.imported = True
                 sys.modules[fullname] = self.module
@@ -33,7 +29,6 @@ class DummyImporterContextTests(testtools.TestCase):
         fml = FakeModuleLoader()
         sys.meta_path.insert(0, fml)
         with DummyImporterContext('zzzxxxvvv.test'):
-            #Py 2 needs __future__.absolute_import
             import zzzxxxvvv.test
             assert_that(fml.module, Is(zzzxxxvvv.test))
         assert_that(sys.modules, Not(Contains('zzzxxxvvv.test')))

--- a/acceptable/tests/test_generate_doubles.py
+++ b/acceptable/tests/test_generate_doubles.py
@@ -1,8 +1,5 @@
 # Copyright 2019 Canonical Ltd.  This software is licensed under the
 # GNU Lesser General Public License version 3 (see the file LICENSE).
-from future import standard_library
-standard_library.install_aliases()
-
 import json
 from io import StringIO
 

--- a/acceptable/tests/test_lint.py
+++ b/acceptable/tests/test_lint.py
@@ -1,7 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Copyright 2017 Canonical Ltd.  This software is licensed under the
 # GNU Lesser General Public License version 3 (see the file LICENSE).
 import testtools

--- a/acceptable/tests/test_main.py
+++ b/acceptable/tests/test_main.py
@@ -1,12 +1,5 @@
 # Copyright 2017 Canonical Ltd.  This software is licensed under the
 # GNU Lesser General Public License version 3 (see the file LICENSE).
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import *  # NOQA
-from future.utils import PY2
-
 import argparse
 from collections import OrderedDict
 import contextlib
@@ -30,13 +23,6 @@ from acceptable.tests._fixtures import (
 )
 
 
-if PY2:
-    # teach yaml about future's newlist and newdict py3 backports
-    from future.types.newlist import newlist
-    from future.types.newdict import newdict
-    SafeRepresenter.add_representer(newlist, SafeRepresenter.represent_list)
-    SafeRepresenter.add_representer(newdict, SafeRepresenter.represent_dict)
-
 
 # sys.exit on error, but rather throws an exception, so we can catch that in
 # our tests:
@@ -51,7 +37,7 @@ class ParseArgsTests(testtools.TestCase):
     def test_error_with_no_args(self):
         self.assertRaisesRegex(
             RuntimeError,
-            'arguments are required' if not PY2 else 'too few arguments',
+            'arguments are required',
             main.parse_args,
             [],
             SaneArgumentParser,
@@ -60,7 +46,7 @@ class ParseArgsTests(testtools.TestCase):
     def test_metadata_requires_files(self):
         self.assertRaisesRegex(
             RuntimeError,
-            'arguments are required' if not PY2 else 'too few arguments',
+            'arguments are required',
             main.parse_args,
             ['metadata'],
             SaneArgumentParser,
@@ -570,7 +556,6 @@ class RenderMarkdownTests(testtools.TestCase):
 
     @testtools.skipIf(
         not builder_installed(), 'documentation-builder not installed')
-    @testtools.skipIf(PY2, 'PY3 only')
     def test_render_cmd_with_documentation_builder(self):
         # documentation-builder is a strict snap, can only work out of $HOME
         home = os.environ['HOME']

--- a/acceptable/tests/test_mocks.py
+++ b/acceptable/tests/test_mocks.py
@@ -1,10 +1,5 @@
 # Copyright 2019 Canonical Ltd.  This software is licensed under the
 # GNU Lesser General Public License version 3 (see the file LICENSE).
-
-from future import standard_library
-
-standard_library.install_aliases()
-
 from acceptable.mocks import (
     CallRecorder,
     Endpoint,

--- a/acceptable/tests/test_service.py
+++ b/acceptable/tests/test_service.py
@@ -1,12 +1,5 @@
 # Copyright 2017 Canonical Ltd.  This software is licensed under the
 # GNU Lesser General Public License version 3 (see the file LICENSE).
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-
-from builtins import *  # NOQA
-
 import json
 
 import jsonschema.exceptions

--- a/acceptable/tests/test_util.py
+++ b/acceptable/tests/test_util.py
@@ -1,7 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Copyright 2017 Canonical Ltd.  This software is licensed under the
 # GNU Lesser General Public License version 3 (see the file LICENSE).
 import testtools

--- a/acceptable/tests/test_validation.py
+++ b/acceptable/tests/test_validation.py
@@ -1,12 +1,5 @@
 # Copyright 2017 Canonical Ltd.  This software is licensed under the
 # GNU Lesser General Public License version 3 (see the file LICENSE).
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import *  # NOQA
-from future.utils import PY2
-
 import json
 import sys
 
@@ -90,10 +83,7 @@ class ValidateBodyTests(TestCase):
             app.post_json,
             []
         )
-        if PY2:
-            msg = "[] is not of type u'object' at /"
-        else:
-            msg = "[] is not of type 'object' at /"
+        msg = "[] is not of type 'object' at /"
         self.assertEqual(
             [msg],
             e.error_list
@@ -169,10 +159,7 @@ class ValidateOutputTests(TestCase):
             []
         )
 
-        if PY2:
-            msg = "[] is not of type u'object' at /"
-        else:
-            msg = "[] is not of type 'object' at /"
+        msg = "[] is not of type 'object' at /"
 
         self.assertEqual(
             'Response does not comply with output schema: %r.\n%s' % (

--- a/acceptable/util.py
+++ b/acceptable/util.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import *  # NOQA
-
 from collections import OrderedDict
 import difflib
 import inspect

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
-future
 coveralls
 fixtures
 testscenarios

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(
     long_description=''.join(open('README.rst').readlines()[2:]),
     long_description_content_type='text/x-rst',
     install_requires=[
-        'future',
         'jinja2',
         'jsonschema',
         'pyyaml',
@@ -31,7 +30,7 @@ setup(
             'Flask<2.0',
         ],
         django=[
-            'django>=2.1',
+            'django>=2.1,<3',
         ]
     ),
     test_suite='acceptable.tests',

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,6 @@ extras =
     flask
     django
 commands =
-    pip uninstall -y argparse
     coverage run --source acceptable --omit "acceptable/tests/*" setup.py test
 passenv =
     TRAVIS


### PR DESCRIPTION
Removed encoding statements from json.load lines, as python 3 basically
asumes that files are encoded utf-8 anyway.