### PR TITLE
Add support for responses > 0.10.2

### DIFF
--- a/acceptable/responses.py
+++ b/acceptable/responses.py
@@ -76,4 +76,8 @@ def wrapper%(signature)s:
         return func%(funcargs)s
 """
         namespace = {'responses_mock_context': self, 'func': func}
-        return responses.get_wrapped(func, wrapper_template, namespace)
+        try:
+            return responses.get_wrapped(func, wrapper_template, namespace)
+        except TypeError:
+            # In responses > 0.10.2, the function definition has changed
+            return responses.get_wrapped(func, self)


### PR DESCRIPTION
The function definition of get_wrapped has changed, so we try which one
works.
This fixes #115