### PR TITLE
README suggests show-acceptable-makefile target

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -147,7 +147,7 @@ The make file assumes the following variables:
 To include the file you'll need to get its path, if the above variables and
 conditions exist you can put this in your make file::
 
-    ACCEPTABLE_MAKEFILE = $(shell realpath --relative-to=. $(shell $(ENV)/bin/python -c 'import pkg_resources; print(pkg_resources.resource_filename("acceptable", "make/Makefile.acceptable"))'))
+    ACCEPTABLE_MAKEFILE = $(shell realpath --relative-to=. $(shell $(ENV)/bin/python -c 'import pkg_resources; print(pkg_resources.resource_filename("acceptable", "make/Makefile.acceptable"))' 2>/dev/null) 2>/dev/null)
 
     -include $(ACCEPTABLE_MAKEFILE)
 

--- a/README.rst
+++ b/README.rst
@@ -147,5 +147,11 @@ The make file assumes the following variables:
 To include the file you'll need to get its path, if the above variables and
 conditions exist you can put this in your make file::
 
-    include $(shell $(ENV)/bin/python -c 'import pkg_resources; print(pkg_resources.resource_filename("acceptable", "make/Makefile.acceptable"))' 2> /dev/null)
+    ACCEPTABLE_MAKEFILE = $(shell realpath --relative-to=. $(shell $(ENV)/bin/python -c 'import pkg_resources; print(pkg_resources.resource_filename("acceptable", "make/Makefile.acceptable"))'))
+
+    -include $(ACCEPTABLE_MAKEFILE)
+
+    .PHONY: show-acceptable-makefile
+    show-acceptable-makefile:
+    	@echo $(ACCEPTABLE_MAKEFILE)
 


### PR DESCRIPTION
The README's suggested makefile snippet for projects that use
acceptable now includes the new target 'show-acceptable-makefile'.

Errors are silenced, otherwise it spams error messages in common
scenarios such as before the virtualenv has been created.

This PR is part of
https://warthogs.atlassian.net/browse/SN-349