### PR TITLE
Newer responses support

### DIFF
--- a/acceptable/responses.py
+++ b/acceptable/responses.py
@@ -78,6 +78,7 @@ def wrapper%(signature)s:
         namespace = {'responses_mock_context': self, 'func': func}
         try:
             return responses.get_wrapped(func, wrapper_template, namespace)
-        except TypeError:
+        except (TypeError, AttributeError):
             # In responses > 0.10.2, the function definition has changed
+            # In responses > 0.20.0, the function definition changed again
             return responses.get_wrapped(func, self)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 
-VERSION = '0.31'
+VERSION = '0.32'
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,10 @@ setup(
     long_description=''.join(open('README.rst').readlines()[2:]),
     long_description_content_type='text/x-rst',
     install_requires=[
-        'jinja2',
+        'Jinja2<3.0,>=2.10.1',
         'jsonschema',
         'pyyaml',
+        'MarkupSafe<2.1',
     ],
     extras_require=dict(
         flask=[


### PR DESCRIPTION
Minimal change, to handle even newer versions of responses correctly