### PR TITLE
Reduce supported python versions to current ones

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python: [3.8, "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+Version 0.33
+
+  * Drop support for python < 3.8, so only Ubuntu LTS 20.04 & 22.204
+
 Version 0.27
 
  * Improvements to the includable make file.

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 
-VERSION = '0.32'
+VERSION = '0.33'
 
 
 setup(
@@ -23,12 +23,11 @@ setup(
     install_requires=[
         'jsonschema',
         'pyyaml',
+        'Jinja2',
     ],
     extras_require=dict(
         flask=[
-            'Flask<2.0',
-            'Jinja2<3.0,>=2.10.1',
-            'MarkupSafe<2.1',
+            'Flask',
         ],
         django=[
             'django>=2.1,<3',

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,12 @@
 [tox]
-envlist = py35, py36, py37, py38, py39
+envlist = py38, py310
 skip_missing_interpreters = True
 skipsdist = True
 
 [gh-actions]
 python =
-    3.5: py35
-    3.6: py36
-    3.7: py37
     3.8: py38
-    3.9: py39
+    3.10: py310
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
Only support python 3.8 and python 3.10.
This also opens up the support for modern versions of Flask & Jinja2