### PR TITLE
Support variables in url

### DIFF
--- a/acceptable/mocks.py
+++ b/acceptable/mocks.py
@@ -278,6 +278,11 @@ class Endpoint(object):
     def __init__(self, base_url, service_name, endpoint_spec, response_callback=None):
         if isinstance(endpoint_spec.location, str):
             self._url = urljoin(base_url, endpoint_spec.location)
+            if self._url.find('<') >0 and self._url.find('<') >0:
+                # we know that there are variable references in the url, so
+                # let's change the url in a regexp
+                self._url=self._url.replace('<', '(?P<').replace('>', '>\S+)')
+                self._url = re.compile(self._url)
         else:
             self._url = endpoint_spec.location
         self._service_name = service_name

--- a/acceptable/mocks.py
+++ b/acceptable/mocks.py
@@ -281,7 +281,7 @@ class Endpoint(object):
             if self._url.find('<') >0 and self._url.find('<') >0:
                 # we know that there are variable references in the url, so
                 # let's change the url in a regexp
-                self._url=self._url.replace('<', '(?P<').replace('>', '>\S+)')
+                self._url=self._url.replace('<', '(?P<').replace('>', '>\S+)').replace('int:', '')
                 self._url = re.compile(self._url)
         else:
             self._url = endpoint_spec.location

--- a/acceptable/mocks.py
+++ b/acceptable/mocks.py
@@ -278,10 +278,10 @@ class Endpoint(object):
     def __init__(self, base_url, service_name, endpoint_spec, response_callback=None):
         if isinstance(endpoint_spec.location, str):
             self._url = urljoin(base_url, endpoint_spec.location)
-            if self._url.find('<') >0 and self._url.find('<') >0:
+            if self._url.find('<') > 0 and self._url.find('<') > 0:
                 # we know that there are variable references in the url, so
                 # let's change the url in a regexp
-                self._url=self._url.replace('<', '(?P<').replace('>', '>\S+)').replace('int:', '')
+                self._url = self._url.replace('<', '(?P<').replace('>', '>\S+)').replace('int:', '')
                 self._url = re.compile(self._url)
         else:
             self._url = endpoint_spec.location

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 
-VERSION = '0.33'
+VERSION = '0.34'
 
 
 setup(


### PR DESCRIPTION
Handle variables inside url definitions for mocks
    
When url's are defined with <variable> definitions in the url, make sure
that these are transformed into regexp urls.
    
Ie change an url from:

    http://localhost:8005/invites/<package_type>/<package_id>/pending
    
To:
    
    http://localhost:8005/invites/(?P<package_type>\S+)/(?P<package_id>\S+)/pending
    
Which will allow responses to match any call that had a random
package_type and package_id

