### PR TITLE
Remove any path: occurances in the regex url

### DIFF
--- a/acceptable/mocks.py
+++ b/acceptable/mocks.py
@@ -281,7 +281,7 @@ class Endpoint(object):
             if self._url.find('<') > 0 and self._url.find('<') > 0:
                 # we know that there are variable references in the url, so
                 # let's change the url in a regexp
-                self._url = self._url.replace('<', '(?P<').replace('>', '>\S+)').replace('int:', '')
+                self._url = self._url.replace('<', '(?P<').replace('>', '>\S+)').replace('int:', '').replace('path:', '')
                 self._url = re.compile(self._url)
         else:
             self._url = endpoint_spec.location

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 
-VERSION = '0.34'
+VERSION = '0.35'
 
 
 setup(


### PR DESCRIPTION
When building the url's in a regexp form, we need to make sure that
invalid datatypes are removed from the string, ie int, path