### PR TITLE
Unpack path parameters

### DIFF
--- a/acceptable/openapi.py
+++ b/acceptable/openapi.py
@@ -19,8 +19,10 @@ class OasOperation:
     operation_id: str
     path_parameters: dict
 
-    def _parameters_to_dict(self):
-        for key, value in self.path_parameters.items():
+    def _parameters_to_openapi(self):
+        # To ensure a stable output we sort the parameter dictionary.
+
+        for key, value in sorted(self.path_parameters.items()):
             yield {
                 "name": key,
                 "in": "path",
@@ -34,7 +36,7 @@ class OasOperation:
             "summary": self.summary,
             "description": tidy_string(self.description) or "None.",
             "operationId": self.operation_id,
-            "parameters": list(self._parameters_to_dict()),
+            "parameters": list(self._parameters_to_openapi()),
             "requestBody": {
                 "content": {
                     "application/json": {

--- a/acceptable/openapi.py
+++ b/acceptable/openapi.py
@@ -25,9 +25,7 @@ class OasOperation:
                 "name": key,
                 "in": "path",
                 "required": True,
-                "schema": {
-                    "type": value
-                }
+                "schema": {"type": value},
             }
 
     def _to_dict(self):

--- a/acceptable/openapi.py
+++ b/acceptable/openapi.py
@@ -129,7 +129,10 @@ def extract_parameters(url: str) -> Tuple[str, dict]:
     url = url.replace("<", "{").replace(">", "}")
 
     # get individual instances of `{...}`
-    raw_parameters = set(re.findall(r"\{.*?}", url))
+    raw_parameters = set(re.findall(r"\{[^}]*}", url))
+    # originally the simpler r"\{.*?}" but SonarLint tells me this approach is safer
+    # it translates as open-curly, zero-or-more-not-close-curly, close-curly
+    # https://rules.sonarsource.com/python/type/Code%20Smell/RSPEC-5857
 
     # extract types from parameters, then
     # re-insert parameters into openapi-style url

--- a/acceptable/openapi.py
+++ b/acceptable/openapi.py
@@ -165,10 +165,10 @@ def extract_parameters(url: str) -> Tuple[str, dict]:
 def dump(metadata: APIMetadata, stream=None):
     oas = OasRoot31()
 
+    _title = "None"
     try:
         [_title] = list(metadata.services.keys())
     except (TypeError, ValueError):
-        _title = "None"
         logging.warning(
             "Could not extract service title from metadata. Expected exactly one valid title."
         )

--- a/acceptable/tests/test_openapi.py
+++ b/acceptable/tests/test_openapi.py
@@ -97,36 +97,36 @@ class TidyStringTests(testtools.TestCase):
 
 class ParameterExtractionTests(testtools.TestCase):
     def test_blank(self):
-        url, parameters = openapi.extract_parameters("")
+        url, parameters = openapi.extract_path_parameters("")
         assert url == ""
         assert parameters == {}
 
     def test_no_parameters(self):
-        url, parameters = openapi.extract_parameters("https://www.example.com")
+        url, parameters = openapi.extract_path_parameters("https://www.example.com")
         assert url == "https://www.example.com"
         assert parameters == {}
 
     def test_simple_parameter(self):
-        url, parameters = openapi.extract_parameters("https://www.example.com/<test>")
+        url, parameters = openapi.extract_path_parameters("https://www.example.com/<test>")
         assert url == "https://www.example.com/{test}"
         assert parameters == {"test": "str"}
 
     def test_typed_parameter(self):
-        url, parameters = openapi.extract_parameters(
+        url, parameters = openapi.extract_path_parameters(
             "https://www.example.com/<test:int>"
         )
         assert url == "https://www.example.com/{test}"
         assert parameters == {"test": "int"}
 
     def test_multiple_typed_parameters(self):
-        url, parameters = openapi.extract_parameters(
+        url, parameters = openapi.extract_path_parameters(
             "https://www.example.com/<test:int>...<test2:float>"
         )
         assert url == "https://www.example.com/{test}...{test2}"
         assert parameters == {"test": "int", "test2": "float"}
 
     def test_ignore_bad_parameter(self):
-        url, parameters = openapi.extract_parameters(
+        url, parameters = openapi.extract_path_parameters(
             "https://www.example.com/<test:int:float>"
         )
         assert url == "https://www.example.com/{test:int:float}"

--- a/acceptable/tests/test_openapi.py
+++ b/acceptable/tests/test_openapi.py
@@ -107,7 +107,9 @@ class ParameterExtractionTests(testtools.TestCase):
         assert parameters == {}
 
     def test_simple_parameter(self):
-        url, parameters = openapi.extract_path_parameters("https://www.example.com/<test>")
+        url, parameters = openapi.extract_path_parameters(
+            "https://www.example.com/<test>"
+        )
         assert url == "https://www.example.com/{test}"
         assert parameters == {"test": "str"}
 

--- a/acceptable/tests/test_openapi.py
+++ b/acceptable/tests/test_openapi.py
@@ -142,7 +142,7 @@ class EndpointToOperationTests(testtools.TestCase):
             service=AcceptableService(name="test service"),
             url="https://test.example",
         )
-        operation = openapi.convert_endpoint_to_operation(endpoint)
+        operation = openapi.convert_endpoint_to_operation(endpoint, {})
         assert "None" == operation.description
         assert "test name" == operation.operation_id
         assert operation.summary is None
@@ -161,7 +161,7 @@ class EndpointToOperationTests(testtools.TestCase):
             url="https://test.example",
         )
         endpoint.docs = "test docs"  # maps to operation.description
-        operation = openapi.convert_endpoint_to_operation(endpoint)
+        operation = openapi.convert_endpoint_to_operation(endpoint, {})
         assert "test docs" == operation.description
         assert "test name" == operation.operation_id
         assert "test title" == operation.summary

--- a/acceptable/tests/test_openapi.py
+++ b/acceptable/tests/test_openapi.py
@@ -95,6 +95,44 @@ class TidyStringTests(testtools.TestCase):
         assert "hello world" == openapi.tidy_string("hello\n world ")
 
 
+class ParameterExtractionTests(testtools.TestCase):
+    def test_blank(self):
+        url, parameters = openapi.extract_parameters("")
+        assert url == ""
+        assert parameters == {}
+
+    def test_no_parameters(self):
+        url, parameters = openapi.extract_parameters("https://www.example.com")
+        assert url == "https://www.example.com"
+        assert parameters == {}
+
+    def test_simple_parameter(self):
+        url, parameters = openapi.extract_parameters("https://www.example.com/<test>")
+        assert url == "https://www.example.com/{test}"
+        assert parameters == {"test": "str"}
+
+    def test_typed_parameter(self):
+        url, parameters = openapi.extract_parameters(
+            "https://www.example.com/<test:int>"
+        )
+        assert url == "https://www.example.com/{test}"
+        assert parameters == {"test": "int"}
+
+    def test_multiple_typed_parameters(self):
+        url, parameters = openapi.extract_parameters(
+            "https://www.example.com/<test:int>...<test2:float>"
+        )
+        assert url == "https://www.example.com/{test}...{test2}"
+        assert parameters == {"test": "int", "test2": "float"}
+
+    def test_ignore_bad_parameter(self):
+        url, parameters = openapi.extract_parameters(
+            "https://www.example.com/<test:int:float>"
+        )
+        assert url == "https://www.example.com/{test:int:float}"
+        assert parameters == {}
+
+
 class EndpointToOperationTests(testtools.TestCase):
     @staticmethod
     def test_blank():

--- a/examples/oas_testcase.py
+++ b/examples/oas_testcase.py
@@ -4,7 +4,7 @@ from acceptable import AcceptableService
 
 service = AcceptableService("OpenApiSample")
 
-foo_api = service.api("/foo", "foo", introduced_at=2)
+foo_api = service.api("/foo/<p:int>/<q>", "foo", introduced_at=2)
 
 foo_api.request_schema = {
     "type": "object",

--- a/examples/oas_testcase_api.json
+++ b/examples/oas_testcase_api.json
@@ -56,7 +56,7 @@
           "4": "Added bar field"
         },
         "title": "Foo",
-        "url": "/foo"
+        "url": "/foo/<p:int>/<q>"
       }
     },
     "title": "Default",

--- a/examples/oas_testcase_expected.yaml
+++ b/examples/oas_testcase_expected.yaml
@@ -15,11 +15,21 @@ info:
   version: 0.0.5
 openapi: 3.1.0
 paths:
-  /foo:
+  /foo/{p}/{q}:
     get:
       description: Documentation goes here.
       operationId: foo
-      parameters: []
+      parameters:
+      - in: path
+        name: q
+        required: true
+        schema:
+          type: str
+      - in: path
+        name: p
+        required: true
+        schema:
+          type: int
       requestBody:
         content:
           application/json:

--- a/examples/oas_testcase_expected.yaml
+++ b/examples/oas_testcase_expected.yaml
@@ -19,6 +19,7 @@ paths:
     get:
       description: Documentation goes here.
       operationId: foo
+      parameters: []
       requestBody:
         content:
           application/json:

--- a/examples/oas_testcase_expected.yaml
+++ b/examples/oas_testcase_expected.yaml
@@ -21,15 +21,15 @@ paths:
       operationId: foo
       parameters:
       - in: path
-        name: q
-        required: true
-        schema:
-          type: str
-      - in: path
         name: p
         required: true
         schema:
           type: int
+      - in: path
+        name: q
+        required: true
+        schema:
+          type: str
       requestBody:
         content:
           application/json:

--- a/examples/oas_testcase_openapi.yaml
+++ b/examples/oas_testcase_openapi.yaml
@@ -15,11 +15,21 @@ info:
   version: 0.0.5
 openapi: 3.1.0
 paths:
-  /foo:
+  /foo/{p}/{q}:
     get:
       description: Documentation goes here.
       operationId: foo
-      parameters: []
+      parameters:
+      - in: path
+        name: q
+        required: true
+        schema:
+          type: str
+      - in: path
+        name: p
+        required: true
+        schema:
+          type: int
       requestBody:
         content:
           application/json:

--- a/examples/oas_testcase_openapi.yaml
+++ b/examples/oas_testcase_openapi.yaml
@@ -19,6 +19,7 @@ paths:
     get:
       description: Documentation goes here.
       operationId: foo
+      parameters: []
       requestBody:
         content:
           application/json:

--- a/examples/oas_testcase_openapi.yaml
+++ b/examples/oas_testcase_openapi.yaml
@@ -21,15 +21,15 @@ paths:
       operationId: foo
       parameters:
       - in: path
-        name: q
-        required: true
-        schema:
-          type: str
-      - in: path
         name: p
         required: true
         schema:
           type: int
+      - in: path
+        name: q
+        required: true
+        schema:
+          type: str
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
Extract parameters from acceptable-style URLs (`path/<parameter:type>`) and express as OpenAPI URLs (`path/{parameter}` with type declared in YAML).